### PR TITLE
Remove javascript client tab

### DIFF
--- a/source/includes/_api.md
+++ b/source/includes/_api.md
@@ -11,10 +11,6 @@ client = CloudifyClient('<manager-ip>')
 import requests
 ```
 
-```html
-CloudifyJS, the JavaScript client, is available at https://github.com/cloudify-cosmo/cloudify-js
-```
-
 Welcome to Cloudify's REST API Documentation!
 
 The base URI for the v2.1 REST API is: `/api/v2.1`.
@@ -60,13 +56,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.blueprints.delete('<blueprint-id>');
-</script>
 ```
 
 > Response Example
@@ -131,13 +120,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.blueprints.get(['my_blueprint1','my_blueprint2'],['id','created_at']);
-</script>
 ```
 
 > Response Example
@@ -415,13 +397,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.manager.get_status();
-</script>
 ```
 
 > Response Example #1

--- a/source/includes/_api_v3.md
+++ b/source/includes/_api_v3.md
@@ -12,10 +12,6 @@ client = CloudifyClient(
         tenant='<manager-tenant>')
 ```
 
-```html
-obsolete
-```
-
 Cloudify 4.0.0 introduced REST API V3.0.
 
 The base URI for the v3.0 REST API is: `/api/v3.0`.

--- a/source/includes/_blueprints.md
+++ b/source/includes/_blueprints.md
@@ -13,10 +13,6 @@ client = CloudifyClient('<manager-ip>')
 import requests
 ```
 
-```html
-CloudifyJS, the JavaScript client, is available at https://github.com/cloudify-cosmo/cloudify-js
-```
-
 ### Attributes:
 
 Attribute | Type | Description
@@ -59,15 +55,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.blueprints.get('hello-world', null, function(err, response, body) {
-                var blueprint = body;
-    });
-</script>
 ```
 
 > Response Example
@@ -143,16 +130,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.blueprints.publish_archive('https://url/to/archive/master.zip',
-                                      '<blueprint-id>','<blueprint-id>.yaml')
-
-    });
-</script>
-```
-
 `PUT "{manager-ip}/api/v2.1/blueprints/{blueprint-id}?application_file_name={blueprint-id}.yaml&
 blueprint_archive_url=https://url/to/archive/master.zip"`
 
@@ -208,15 +185,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.blueprints.list('<blueprint-id>', function(err, response, body){
-                var blueprints = body.items;
-    });
-</script>
-```
-
 `GET "{manager-ip}/api/v2.1/blueprints"`
 
 Lists all blueprints.
@@ -258,13 +226,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.blueprints.delete('<blueprint-id>')
-</script>
 ```
 
 `DELETE "{manager-ip}/api/v2.1/blueprints/{blueprint-id}"`
@@ -310,13 +271,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.download('<blueprint-id>')
-</script>
 ```
 
 `GET "{manager-ip}/api/v2.1/blueprints/{blueprint-id}/archive"`

--- a/source/includes/_cluster.md
+++ b/source/includes/_cluster.md
@@ -57,10 +57,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-obsolete
-```
-
 > Response Example (cluster not initialized)
 
 ```json
@@ -143,9 +139,6 @@ $ curl -X PUT -H "Content-Type: application/json" -H "tenant: <tenant-name>" -u 
 ```
 
 
-```html
-obsolete
-```
 > Response Example
 
 ```json
@@ -210,10 +203,6 @@ $.ajax(settings).done(function (response) {
 
 ```shell
 $ curl -X PATCH -H "Content-Type: application/json" -H "tenant: <tenant-name>" -d '{"config_key": "config_value"}' -u user:password "http://<manager-ip>/api/v3/cluster"
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -283,10 +272,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-obsolete
-```
-
 > Response Example
 
 ```json
@@ -345,10 +330,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-obsolete
-```
-
 > Response Example
 
 ```json
@@ -401,10 +382,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example

--- a/source/includes/_deployments.md
+++ b/source/includes/_deployments.md
@@ -13,10 +13,6 @@ client = CloudifyClient('<manager-ip>')
 import requests
 ```
 
-```html
-CloudifyJS, the JavaScript client, is available at https://github.com/cloudify-cosmo/cloudify-js
-```
-
 ### Attributes:
 
 Attribute | Type | Description
@@ -64,13 +60,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.deployments.get('hello1');
-</script>
 ```
 
 > Response Example
@@ -188,15 +177,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.deployments.list(null, function(err, response, body){
-                var deployments = body.items;
-    });
-</script>
-```
-
 `GET "{manager-ip}/api/v2.1/deployments"`
 
 Lists all deployments.
@@ -247,14 +227,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.deployments.create('<blueprint-id>', '<deployment-id>',
-                              {'image':'<image-id>','flavor':'<flavor-id>','agent_user':'<user-name>'});
-</script>
-```
-
 `PUT -d '{"inputs":{...}, "blueprint_id":"<blueprint-id>"}' "{manager-ip}/api/v2.1/deployments/{deployment-id}"`
 
 Creates a new deployment.
@@ -302,13 +274,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.deployments.delete('<deployment-id>');
-</script>
 ```
 
 `DELETE "{manager-ip}/api/v2.1/deployments/{deployment-id}"`

--- a/source/includes/_events.md
+++ b/source/includes/_events.md
@@ -13,10 +13,6 @@ client = CloudifyClient('<manager-ip>')
 import requests
 ```
 
-```html
-CloudifyJS, the JavaScript client, is available at https://github.com/cloudify-cosmo/cloudify-js
-```
-
 ### Attributes:
 
 Attribute | Type | Description
@@ -90,13 +86,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.events.get( { execution_id : <execution-id> } );
-</script>
 ```
 
 > Response Example

--- a/source/includes/_executions.md
+++ b/source/includes/_executions.md
@@ -13,10 +13,6 @@ client = CloudifyClient('<manager-ip>')
 import requests
 ```
 
-```html
-CloudifyJS, the JavaScript client, is available at https://github.com/cloudify-cosmo/cloudify-js
-```
-
 ### Attributes:
 
 Attribute | Type | Description
@@ -66,15 +62,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.executions.get('execution-id', null, function(err, response, body) {
-                    var execution = body;
-    });
-</script>
 ```
 
 > Response Example
@@ -144,15 +131,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.executions.list({_include: 'id'}, function(err, response, body){
-                var executions = body.items;
-    });
-</script>
-```
-
 `GET "{manager-ip}/api/v2.1/executions?deployment_id={deployment-id}"`
 
 Lists all executions.
@@ -197,18 +175,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.deployments.get('<deployment-id>', null, function (err, response, body) {
-                var deployment = body;
-                var workflow = _.find(deployment.workflows, {'name': 'install'});
-
-                client.executions.start('<deployment-id>', workflow.name, workflow.parameters, false, false);
-    });
-</script>
 ```
 
 `POST -d '{"deployment_id":{deployments-id}, "workflow_id":"<workflow-id>"}' "{manager-ip}/api/v2.1/executions"`
@@ -261,13 +227,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.executions.cancel(execution.id, true);
-</script>
 ```
 
 `POST -d '{"deployment_id":{deployment-id}, "action":"<action-method>"}' "{manager-ip}/api/v2.1/executions/{execution-id}"`

--- a/source/includes/_manager.md
+++ b/source/includes/_manager.md
@@ -13,10 +13,6 @@ client = CloudifyClient('<manager-ip>')
 import requests
 ```
 
-```html
-CloudifyJS, the JavaScript client, is available at https://github.com/cloudify-cosmo/cloudify-js
-```
-
 ## Status
 
 > Request Example
@@ -47,13 +43,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.manager.get_status();
-</script>
 ```
 
 > Response Example
@@ -158,13 +147,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.manager.get_version();
-</script>
 ```
 
 > Response Example

--- a/source/includes/_node_instances.md
+++ b/source/includes/_node_instances.md
@@ -13,10 +13,6 @@ client = CloudifyClient('<manager-ip>')
 import requests
 ```
 
-```html
-CloudifyJS, the JavaScript client, is available at https://github.com/cloudify-cosmo/cloudify-js
-```
-
 ### Attributes:
 
 Attribute | Type | Description
@@ -60,13 +56,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.nodeInstances.get('vm_150f1', null);
-</script>
 ```
 
 > Response Example
@@ -133,13 +122,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.nodeInstances.list('<deployment-id>', null);
-</script>
 ```
 
 > Response Example
@@ -253,17 +235,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    var newState = 'starting';
-    var newProperties = {
-        'key': 'value'
-    };
-    client.nodeInstances.update('<node-instance-id>', newState, newProperties, 0)
-</script>
 ```
 
 > Response Example

--- a/source/includes/_nodes.md
+++ b/source/includes/_nodes.md
@@ -13,10 +13,6 @@ client = CloudifyClient('<manager-ip>')
 import requests
 ```
 
-```html
-CloudifyJS, the JavaScript client, is available at https://github.com/cloudify-cosmo/cloudify-js
-```
-
 ### Attributes:
 
 Attribute | Type | Description
@@ -71,13 +67,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.nodes.list('<deployment-id>', null, null)
-</script>
 ```
 
 > Response Example

--- a/source/includes/_plugins.md
+++ b/source/includes/_plugins.md
@@ -13,10 +13,6 @@ client = CloudifyClient('<manager-ip>')
 import requests
 ```
 
-```html
-CloudifyJS, the JavaScript client, is available at https://github.com/cloudify-cosmo/cloudify-js
-```
-
 ### Attributes:
 
 Attribute | Type | Description
@@ -67,13 +63,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.plugins.get( { plugin_id_id : <plugin-id> } );
-</script>
 ```
 
 > Response Example
@@ -142,13 +131,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.plugins.delete( { plugin_id_id : <plugin-id> } );
-</script>
-```
-
 `DELETE "{manager-ip}/api/v2.1/plugins/{plugin-id}"`
 
 Deletes a plugin from the Cloudify-Manager.
@@ -199,15 +181,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.plugins.list(function(err, response, body){
-                var plugins = body.items;
-    });
-</script>
-```
-
 `GET "{manager-ip}/api/v2.1/plugins"`
 
 Lists all plugins.
@@ -251,13 +224,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.plugins.upload('https://url/to/archive.zip');
-</script>
 ```
 
 `POST "{manager-ip}/api/v2.1/plugins/{plugin-id}"`
@@ -305,13 +271,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.plugins.download('<plugin-id>');
-</script>
 ```
 
 `GET "{manager-ip}/api/v2.1/plugins/{plugin-id}/archive"`

--- a/source/includes/_secrets.md
+++ b/source/includes/_secrets.md
@@ -14,10 +14,6 @@ client = CloudifyClient(
         tenant='<manager-tenant>')
 ```
 
-```html
-
-```
-
 A Secret resource is a key-value pair saved per tenant.
 A user can ensure all secrets (such as credentials to IaaS environments, passwords, etc) are kept in a secured manner,
 and adhere to isolation requirements between different tenants.
@@ -63,10 +59,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -126,10 +118,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -195,10 +183,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -268,10 +252,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-obsolete
-```
-
 > Response Example
 
 ```json
@@ -334,10 +314,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example

--- a/source/includes/_snapshots.md
+++ b/source/includes/_snapshots.md
@@ -13,10 +13,6 @@ client = CloudifyClient('<manager-ip>')
 import requests
 ```
 
-```html
-CloudifyJS, the JavaScript client, is available at https://github.com/cloudify-cosmo/cloudify-js
-```
-
 ### Attributes:
 
 
@@ -59,15 +55,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.snapshots.list(function(err, response, body){
-              var snapshots = body.items;
-  });
-</script>
 ```
 
 > Response Example
@@ -142,13 +129,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.snapshots.create('<snapshot-id>');
-</script>
-```
-
 `PUT "{manager-ip}/api/v2.1/snapshots/{snapshot-id}"`
 
 Creates a new snapshot.
@@ -196,13 +176,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-<script>
-    var client = new window.CloudifyClient({'endpoint': 'http://<manager-ip>/api/v2.1'});
-    client.snapshots.delete('<snapshot-id>');
-</script>
 ```
 
 `DELETE "{manager-ip}/api/v2.1/snapshots/{snapshot-id}"`

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -18,10 +18,6 @@ client = CloudifyClient(
         tenant='<manager-tenant>')
 ```
 
-```html
-
-```
-
 The Tenant resource is a logical component that represents a closed environment with its own resources.
 
 
@@ -62,10 +58,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -121,10 +113,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -184,10 +172,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-obsolete
-```
-
 > Response Example
 
 ```json
@@ -241,10 +225,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -306,10 +286,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -377,10 +353,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-obsolete
-```
-
 > Response Example
 
 ```json
@@ -446,10 +418,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-obsolete
-```
-
 > Response Example
 
 ```json
@@ -513,10 +481,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example

--- a/source/includes/_tokens.md
+++ b/source/includes/_tokens.md
@@ -13,10 +13,6 @@ client = CloudifyClient('<manager-ip>')
 import requests
 ```
 
-```html
-CloudifyJS, the JavaScript client, is available at https://github.com/cloudify-cosmo/cloudify-js
-```
-
 ### Attributes:
 
 Attribute | Type | Description

--- a/source/includes/_user_group.md
+++ b/source/includes/_user_group.md
@@ -18,10 +18,6 @@ client = CloudifyClient(
         tenant='<manager-tenant>')
 ```
 
-```html
-
-```
-
 The User Group is a group of users.
 
 
@@ -65,10 +61,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -125,10 +117,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -195,10 +183,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-obsolete
-```
-
 > Response Example
 
 ```json
@@ -257,10 +241,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -323,10 +303,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -393,10 +369,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -18,10 +18,6 @@ client = CloudifyClient(
         tenant='<manager-tenant>')
 ```
 
-```html
-
-```
-
 Since Cloudify 4.0, Cloudify user management has been added
 
 
@@ -70,10 +66,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -132,10 +124,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -207,10 +195,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-obsolete
-```
-
 > Response Example
 
 ```json
@@ -274,10 +258,6 @@ $.ajax(settings).done(function (response) {
 });
 ```
 
-```html
-obsolete
-```
-
 > Response Example
 
 ```json
@@ -338,10 +318,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example
@@ -409,10 +385,6 @@ var settings = {
 $.ajax(settings).done(function (response) {
   console.log(response);
 });
-```
-
-```html
-obsolete
 ```
 
 > Response Example

--- a/source/index.md
+++ b/source/index.md
@@ -8,7 +8,6 @@ language_tabs:
   - shell: cURL
   - python: Python
   - javascript: JQuery AJAX
-  - html: JavaScript Client
 
 includes:
   - api


### PR DESCRIPTION
In this PR, the javascript client tab is removed from the API documentation.

The reason for this is that I've seen in multiple places in the documentation that is marked as obsolete. 

Also note that this is part of a clean up to update the documentation for the API v3, if this is relevant still for API v2.1 that part of the documentation is still available in the `api-v2.1` branch.