### PR TITLE
Remove dry-run flag

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,6 @@ deployment:
   production:
     branch: master
     commands:
-      - bundle exec s3_website push --verbose --dry-run
+      - bundle exec s3_website push --verbose
       - sudo pip install boto
       - python make_public.py


### PR DESCRIPTION
The experiment to deploy v3 documentation worked as expected, so now the dry-run flag can be removed.

In particular the `s3_website` output makes clear that the documentation changes will be pushed to `/api/v3`:
```
bundle exec s3_website push --verbose --dry-run
[info] Downloading https://github.com/laurilehmijoki/s3_website/releases/download/v2.12.3/s3_website.jar into /home/ubuntu/.rvm/gems/ruby-2.2.1/gems/s3_website-2.12.3/s3_website-2.12.3.jar
[debg] Using /home/ubuntu/.rvm/gems/ruby-2.2.1/gems/s3_website-2.12.3/s3_website-2.12.3.jar
[info] Simulating the deployment of /home/ubuntu/cloudify-rest-docs/build/* to docs.getcloudify.org
[debg] Querying S3 files
[debg] Ignoring all files on the bucket, since the setting _DELETE_NOTHING_ON_THE_S3_BUCKET_ is on.
[debg] Querying more S3 files (starting from 3.4.0/images/logo.png)
[debg] Querying more S3 files (starting from 3.4.2/workflows/index.html)
[debg] Querying more S3 files (starting from dev/blueprints/spec-outputs/index.html)
[succ] Would have created api/v3/fonts/slate.woff2 (max-age=300 | application/octet-stream | REDUCED_REDUNDANCY | 796 B)
[succ] Would have created api/v3/stylesheets/print.css (max-age=300 | text/css; charset=utf-8 | REDUCED_REDUNDANCY | 4.3 kB)
[succ] Would have created api/v3/javascripts/all.js (max-age=300 | application/javascript | REDUCED_REDUNDANCY | 45.9 kB)
[succ] Would have created api/v3/fonts/slate.ttf (max-age=300 | application/x-font-ttf | REDUCED_REDUNDANCY | 1.7 kB)
[succ] Would have created api/v3/images/logo.png (max-age=300 | image/png | REDUCED_REDUNDANCY | 24.2 kB)
[succ] Would have created api/v3/stylesheets/screen.css (max-age=300 | text/css; charset=utf-8 | REDUCED_REDUNDANCY | 13.0 kB)
[succ] Would have created api/v3/javascripts/all_nosearch.js (max-age=300 | application/javascript | REDUCED_REDUNDANCY | 26.6 kB)
[succ] Would have created api/v3/images/navbar.png (max-age=300 | image/png | REDUCED_REDUNDANCY | 96 B)
[succ] Would have created api/v3/index.html (max-age=300 | text/html; charset=utf-8 | REDUCED_REDUNDANCY | 401.0 kB)
[succ] Would have created api/v3/fonts/slate.eot (max-age=300 | application/vnd.ms-fontobject | REDUCED_REDUNDANCY | 1.9 kB)
[succ] Would have created api/v3/fonts/slate.svg (max-age=300 | image/svg+xml | REDUCED_REDUNDANCY | 2.9 kB)
[succ] Would have created api/v3/fonts/slate.woff (max-age=300 | application/octet-stream | REDUCED_REDUNDANCY | 1.8 kB)
[info] Summary: Would have created 12 files. Would have transferred 524.2 kB.
```