### PR TITLE
Use api v2 prefix

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
   override:
     - bundle install:
         timeout: 3600
-    - rake build:
+    - bundle exec rake build:
         timeout: 3600
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,6 @@ deployment:
   production:
     branch: master
     commands:
-      - mv build api; mkdir build; mv api build
       - bundle exec s3_website push --verbose
       - sudo pip install boto
       - python make_public.py

--- a/circle.yml
+++ b/circle.yml
@@ -23,7 +23,7 @@ test:
 ## Customize deployment commands
 deployment:
   production:
-    branch: master
+    branch: 2-build
     commands:
       - bundle exec s3_website push --verbose --dry-run
       - sudo pip install boto

--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,6 @@ deployment:
   production:
     branch: master
     commands:
-      - bundle exec s3_website push --verbose
+      - bundle exec s3_website push --verbose --dry-run
       - sudo pip install boto
       - python make_public.py

--- a/make_public.py
+++ b/make_public.py
@@ -17,7 +17,7 @@ def make_api_docs_public():
         os.environ['S3_SECRET_KEY'],
         calling_format=boto.s3.connection.OrdinaryCallingFormat())
     bucket = conn.get_bucket('docs.getcloudify.org')
-    api_keys = bucket.get_all_keys(prefix='api')
+    api_keys = bucket.list(prefix='api/v2')
     for key in api_keys:
         print('   Making "{0}" public..'.format(key.name))
         key.make_public()

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,6 +1,7 @@
 s3_id: <%= ENV['S3_ACCESS_KEY_ID'] %>
 s3_secret: <%= ENV['S3_SECRET_KEY'] %>
 s3_bucket: docs.getcloudify.org
+s3_key_prefix: api/v2
 
 # Below are examples of all the available configurations.
 # See README for more detailed info on each of them.


### PR DESCRIPTION
In this PR, the api/v2 prefix is used to upload the documentation files to the s3 bucket.

The --dry-run flag has been added to the CircleCI configuration to make sure everything looks good before really uploading the documentation files after a build (that will be done in a separate PR).

This is part of the changes to push the documentation sites for api v2, v2.1 and v3 to the same s3 bucket.