### PR TITLE
CFY-6412. Add tenant examples using get data flag

### DIFF
--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -435,7 +435,7 @@ response.json()
   "name": "<tenant-name>",
   "groups": {},
   "users": {
-    "my-user": {
+    "<user>": {
       "tenant-role": "<role>",
       "roles": [
         "<role>"
@@ -649,7 +649,7 @@ A `Tenant` resource.
 
 ## Add User-Group to Tenant
 
-> Request Example
+> Request Example - Get user and user group counts
 
 ```shell
 $ curl -X PUT \
@@ -676,13 +676,52 @@ response = requests.put(url, auth=auth, headers=headers, json=payload)
 response.json()
 ```
 
-> Response Example
+> Response Example - Get user and user group counts
 
 ```json
 {
     "name": "tenant-name",
     "groups": 1,
     "users": 0
+}
+```
+
+> Request Example - Get user and user group details
+
+```shell
+$ curl -X PUT \
+    -H "Content-Type: application/json" \
+    -H "Tenant: <tenant-name>" \
+    -u <user>:<password> \
+    -d '{"group_name": <group-name>, "tenant_name": <tenant-name>, "role": <role-name>}' \
+    "http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true"
+```
+
+```python
+# Using Cloudify client
+client.tenants.add_user_group(<group-name>, <tenant-name>, <role>, _get_data=True)
+
+# Using requests
+url = 'http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true'
+headers = {'Tenant': '<tenant-name>'}
+payload = {
+    'tenant_name': <tenant-name>,
+    'group_name': <group-name>,
+    'role': <role_name>,
+}
+response = requests.put(url, auth=auth, headers=headers, json=payload)
+response.json()
+```
+
+> Response Example - Get user and user group details
+
+```json
+{
+  "name": "<tenant-name>",
+  "groups": {
+    "<group-name>": "<role>"
+  },
+  "users": {}
 }
 ```
 

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -370,7 +370,7 @@ A `Tenant` resource.
 
 ## Add User to Tenant
 
-> Request Example
+> Request Example - Get user and user group counts
 
 ```shell
 $ curl -X PUT \
@@ -386,32 +386,66 @@ $ curl -X PUT \
 client.tenants.add_user(<user-name>, <tenant-name>, <role>)
 
 # Using requests
-import requests
-from requests.auth import HTTPBasicAuth
-
 url = 'http://<manager-ip>/api/v3.1/tenants/users'
-headers = {'Tenant': '<tenant-name>'}
 payload = {
     'tenant_name': <tenant-name>,
     'username': <user>,
     'role': <role_name>,
 }
-response = requests.get(
-    url,
-    auth=HTTPBasicAuth(<user>, <password>),
-    headers=headers,
-    json=payload,
-)
+response = requests.get(url, auth=auth, headers=headers, json=payload)
 response.json()
 ```
 
-> Response Example
+> Response Example - Get user and user group counts
 
 ```json
 {
     "name": "<tenant-name>",
     "groups": 0,
     "users": 1
+}
+```
+
+> Request Example - Get user and user group details
+
+```shell
+$ curl -X PUT \
+    -H "Content-Type: application/json" \
+    -H "Tenant: <tenant-name>" \
+    -u <user>:<password> \
+    -d '{"username": <user-name>, "tenant_name": <tenant-name>, "role": <role_name>}' \
+    "http://<manager-ip>/api/v3.1/tenants/users?_get_data=true"
+```
+
+```python
+# Using Cloudify client
+client.tenants.add_user(<user-name>, <tenant-name>, <role>)
+
+# Using requests
+url = 'http://<manager-ip>/api/v3.1/tenants/users?_get_data=true'
+payload = {
+    'tenant_name': <tenant-name>,
+    'username': <user>,
+    'role': <role_name>,
+}
+response = requests.get(url, auth=auth, headers=headers, json=payload, _get_data=True)
+response.json()
+```
+
+> Response Example - Get user and user group details
+
+```json
+{
+  "name": "<tenant-name>",
+  "groups": {},
+  "users": {
+    "my-user": {
+      "tenant-role": "<role>",
+      "roles": [
+        "<role>"
+      ]
+    }
+  }
 }
 ```
 

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -6,17 +6,6 @@
 This section describes API features that are part of the Cloudify premium edition
 </aside>
 
-> `Note`
-
-```python
-# Include this code when using python requests
-import requests
-from requests.auth import HTTPBasicAuth
-
-headers = {'Tenant': '<tenant_name>'}
-auth = HTTPBasicAuth('<username>', '<password>')
-```
-
 The Tenant resource is a logical component that represents a closed environment with its own resources.
 
 
@@ -51,8 +40,17 @@ client = CloudifyClient(
 client.tenants.list()
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants'
-response = requests.get(url, auth=auth, headers=headers)
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+response = requests.get(
+    url,
+    auth=auth,
+    headers=headers,
+)
 response.json()
 ```
 
@@ -98,8 +96,17 @@ client = CloudifyClient(
 client.tenants.list(_get_data=True)
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants?_get_data=true'
-response = requests.get(url, auth=auth, headers=headers)
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+response = requests.get(
+    url,
+    auth=auth,
+    headers=headers,
+)
 response.json()
 ```
 
@@ -164,8 +171,17 @@ client = CloudifyClient(
 client.tenants.get('default_tenant')
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/<tenant_name>'
-response = requests.get(url, auth=auth, headers=headers)
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+response = requests.get(
+    url,
+    auth=auth,
+    headers=headers,
+)
 response.json()
 ```
 
@@ -200,8 +216,17 @@ client = CloudifyClient(
 client.tenants.get('default_tenant', _get_data=True)
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/<tenant_name>?_get_data=true'
-response = requests.get(url, auth=auth, headers=headers)
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+response = requests.get(
+    url,
+    auth=auth,
+    headers=headers,
+)
 response.json()
 ```
 
@@ -258,8 +283,17 @@ client = CloudifyClient(
 client.tenants.create('<new_tenant_name>')
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/<new_tenant_name>'
-response = requests.post(url, auth=auth, headers=headers)
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+response = requests.post(
+    url,
+    auth=auth,
+    headers=headers,
+)
 response.json()
 ```
 
@@ -295,8 +329,17 @@ client = CloudifyClient(
 client.tenants.create('<new_tenant_name>', _get_data=True)
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/<new_tenant_name>?_get_data=true'
-response = requests.post(url, auth=auth, headers=headers)
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+response = requests.post(
+    url,
+    auth=auth,
+    headers=headers,
+)
 response.json()
 ```
 
@@ -346,8 +389,17 @@ client = CloudifyClient(
 client.tenants.delete('<tenant_name_to_delete>')
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/<tenant_name-to-delete>'
-response = requests.delete(url, auth=auth, headers=headers)
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+response = requests.delete(
+    url,
+    auth=auth,
+    headers=headers,
+)
 response.json()
 
 ```
@@ -383,8 +435,17 @@ client = CloudifyClient(
 client.tenants.delete('<tenant_name_to_delete>', _get_data=True)
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/<tenant_name_to_delete>?_get_data=true'
-response = requests.delete(url, auth=auth, headers=headers)
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+response = requests.delete(
+    url,
+    auth=auth,
+    headers=headers,
+)
 response.json()
 
 ```
@@ -441,13 +502,23 @@ client.tenants.add_user(
 )
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/users'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
     'username': '<username>',
     'role': '<role_name>',
 }
-response = requests.get(url, auth=auth, headers=headers, json=payload)
+response = requests.get(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
 response.json()
 ```
 
@@ -489,13 +560,24 @@ client.tenants.add_user(
 )
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/users?_get_data=true'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
     'username': '<username>',
     'role': '<role_name>',
 }
-response = requests.get(url, auth=auth, headers=headers, json=payload, _get_data=True)
+response = requests.get(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+    _get_data=True,
+)
 response.json()
 ```
 
@@ -562,13 +644,23 @@ client.tenants.update_user(
 )
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/users'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
     'username': '<username>',
     'role': '<role_name>',
 }
-response = requests.patch(url, auth=auth, headers=headers, json=payload)
+response = requests.patch(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
 response.json()
 ```
 
@@ -610,13 +702,23 @@ client.tenants.update_user(
 )
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/users?_get_data=true'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
     'username': '<username>',
     'role': '<role_name>',
 }
-response = requests.patch(url, auth=auth, headers=headers, json=payload)
+response = requests.patch(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
 response.json()
 ```
 
@@ -677,12 +779,22 @@ client = CloudifyClient(
 client.tenants.remove_user('<username>', '<tenant_name>')
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/users'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
     'username': '<username>',
 }
-response = requests.delete(url, auth=auth, headers=headers, json=payload)
+response = requests.delete(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
 response.json()
 ```
 
@@ -723,12 +835,22 @@ client.tenants.remove_user(
 )
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/users?_get_data=true'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
     'username': '<username>',
 }
-response = requests.delete(url, auth=auth, headers=headers, json=payload)
+response = requests.delete(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
 response.json()
 ```
 
@@ -788,14 +910,23 @@ client.tenants.add_user_group(
 )
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/user-groups'
-headers = {'Tenant': '<tenant_name>'}
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
     'group_name': '<group_name>',
     'role': '<role_name>',
 }
-response = requests.put(url, auth=auth, headers=headers, json=payload)
+response = requests.put(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
 response.json()
 ```
 
@@ -837,14 +968,23 @@ client.tenants.add_user_group(
 )
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true'
-headers = {'Tenant': '<tenant_name>'}
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
     'group_name': '<group_name>',
     'role': '<role_name>',
 }
-response = requests.put(url, auth=auth, headers=headers, json=payload)
+response = requests.put(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
 response.json()
 ```
 
@@ -906,13 +1046,23 @@ client.tenants.update_user_group(
 )
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/user-groups'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
     'group_name': '<group_name>',
     'role': '<role_name>',
 }
-response = requests.patch(url, auth=auth, headers=headers, json=payload)
+response = requests.patch(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
 response.json()
 ```
 
@@ -954,13 +1104,23 @@ client.tenants.update_user_group(
 )
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
     'group_name': '<group_name>',
     'role': '<role_name>',
 }
-response = requests.patch(url, auth=auth, headers=headers, json=payload)
+response = requests.patch(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
 response.json()
 ```
 
@@ -1017,12 +1177,22 @@ client = CloudifyClient(
 client.tenants.remove_user_group('<group_name>', '<tenant_name>')
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/user-groups'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
     'group_name': '<group_name>',
 }
-response = requests.delete(url, auth=auth, headers=headers, json=payload)
+response = requests.delete(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
 response.json()
 ```
 
@@ -1063,13 +1233,22 @@ client.tenants.remove_user_group(
 )
 
 # Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
 url = 'http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true'
-headers = {'Tenant': '<tenant_name>'}
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
     'group_name': '<group_name>',
 }
-response = requests.delete(url, auth=auth, headers=headers, json=payload)
+response = requests.delete(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
 response.json()
 ```
 

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -221,7 +221,7 @@ A `Tenant` resource.
 
 ## Create Tenant
 
-> Request Example
+> Request Example - Get user and user group counts
 
 ```shell
 $ curl -X POST \
@@ -235,16 +235,12 @@ $ curl -X POST \
 client.tenants.create(<new-tenant-name>)
 
 # Using requests
-import requests
-from requests.auth import HTTPBasicAuth
-
 url = 'http://<manager-ip>/api/v3.1/tenants/<new-tenant-name>'
-headers = {'Tenant': '<tenant-name>'}
-response = requests.post(url, auth=HTTPBasicAuth(<user>, <password>), headers=headers)
+response = requests.post(url, auth=auth, headers=headers)
 response.json()
 ```
 
-> Response Example
+> Response Example - Get user and user group counts
 
 ```json
 {
@@ -254,6 +250,35 @@ response.json()
 }
 ```
 
+> Request Example - Get user and user group details
+
+
+```shell
+$ curl -X POST \
+    -H "Tenant: <tenant-name>" \
+    -u <user>:<password> \
+    "http://<manager-ip>/api/v3.1/tenants/<new-tenant-name>?_get_data=true"
+```
+
+```python
+# Using Cloudify client
+client.tenants.create(<new-tenant-name>, _get_data=True)
+
+# Using requests
+url = 'http://<manager-ip>/api/v3.1/tenants/<new-tenant-name>?_get_data=true'
+response = requests.post(url, auth=auth, headers=headers)
+response.json()
+```
+
+> Response Example - Get user and user group details
+
+```json
+{
+    "name": "<new-tenant-name>",
+    "groups": {},
+    "users": {}
+}
+```
 `POST "{manager-ip}/api/v3.1/tenants/{new-tenant-name}"`
 
 Creates a tenant.

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -836,7 +836,7 @@ A `Tenant` resource.
 
 ## Remove User-Group from Tenant
 
-> Request Example
+> Request Example - Get user and user group counts
 
 ```shell
 $ curl -X DELETE \
@@ -853,7 +853,6 @@ client.tenants.remove_user_group(<group-name>, <tenant-name>)
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/user-groups'
-headers = {'Tenant': '<tenant-name>'}
 payload = {
     'tenant_name': <tenant-name>,
     'group_name': <user>,
@@ -862,7 +861,7 @@ response = requests.delete(url, auth=auth, headers=headers, json=payload)
 response.json()
 ```
 
-> Response Example
+> Response Example - Get user and user group counts
 
 ```json
 {
@@ -872,6 +871,41 @@ response.json()
 }
 ```
 
+> Request Example - Get user and user group details
+
+```shell
+$ curl -X DELETE \
+    -H "Content-Type: application/json" \
+    -H "Tenant: <tenant-name>" \
+    -u <user>:<password> \
+    -d '{"group_name": <group-name>, "tenant_name": <tenant-name>}' \
+    "http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true"
+```
+
+```python
+# Using Cloudify client
+client.tenants.remove_user_group(<group-name>, <tenant-name>, _get_data=True)
+
+# Using requests
+url = 'http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true'
+headers = {'Tenant': '<tenant-name>'}
+payload = {
+    'tenant_name': <tenant-name>,
+    'group_name': <user>,
+}
+response = requests.delete(url, auth=auth, headers=headers, json=payload)
+response.json()
+```
+
+> Response Example - Get user and user group details
+
+```json
+{
+    "name": "tenant-name",
+    "groups": {},
+    "users": {}
+}
+```
 `DELETE "{manager-ip}/api/v3.1/tenants/user-groups"`
 
 Delete a user group from a tenant.

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -744,7 +744,7 @@ A `Tenant` resource.
 ## Update User-Group in Tenant
 
 
-> Request Example
+> Request Example - Get user and user group counts
 
 ```shell
 $ curl -X PATCH \
@@ -761,7 +761,6 @@ client.tenants.update_user_group(<group-name>, <tenant-name>, <role-name>)
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/user-groups'
-headers = {'Tenant': '<tenant-name>'}
 payload = {
     'tenant_name': <tenant-name>,
     'group_name': <group-name>,
@@ -771,13 +770,51 @@ response = requests.patch(url, auth=auth, headers=headers, json=payload)
 response.json()
 ```
 
-> Response Example
+> Response Example - Get user and user group counts
 
 ```json
 {
     "name": "tenant-name",
-    "groups": 0,
-    "users": 1
+    "groups": 1,
+    "users": 0
+}
+```
+
+> Request Example - Get user and user group details
+
+```shell
+$ curl -X PATCH \
+    -H "Content-Type: application/json"
+    -H "Tenant: <tenant-name>" \
+    -u <user>:<password> \
+    -d '{"username": <user-name>, "group_name": <group-name>, "role": <role-name>}' \
+     "http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true"
+```
+
+```python
+# Using Cloudify client
+client.tenants.update_user_group(<group-name>, <tenant-name>, <role-name>, _get_data=True)
+
+# Using requests
+url = 'http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true'
+payload = {
+    'tenant_name': <tenant-name>,
+    'group_name': <group-name>,
+    'role': <role-name>,
+}
+response = requests.patch(url, auth=auth, headers=headers, json=payload)
+response.json()
+```
+
+> Response Example - Get user and user group details
+
+```json
+{
+  "name": "<tenant-name>",
+  "groups": {
+    "<group-name>": "<role>"
+  },
+  "users": {}
 }
 ```
 

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -9,13 +9,20 @@ This section describes API features that are part of the Cloudify premium editio
 > `Note`
 
 ```python
-# include this code when using cloudify python client-
+# Include this code when using the Cloudify client
 from cloudify_rest_client import CloudifyClient
 client = CloudifyClient(
         host='<manager-ip>',
         username='<manager-username>',
         password='<manager-password>',
         tenant='<manager-tenant>')
+
+# Include this code when using python requests
+import requests
+from requests.auth import HTTPBasicAuth
+
+headers = {'Tenant': '<tenant-name>'}
+auth = HTTPBasicAuth(<user>, <password>)
 ```
 
 The Tenant resource is a logical component that represents a closed environment with its own resources.
@@ -31,7 +38,7 @@ Attribute | Type | Description
 
 ## List Tenants
 
-> Request Example
+> Request Example - Get user and user group counts
 
 ```shell
 $ curl -X GET \
@@ -45,16 +52,12 @@ $ curl -X GET \
 client.tenants.list()
 
 # Using requests
-import requests
-from requests.auth import HTTPBasicAuth
-
 url = 'http://<manager-ip>/api/v3.1/tenants'
-headers = {'Tenant': '<tenant-name>'}
-response = requests.get(url, auth=HTTPBasicAuth(<user>, <password>), headers=headers)
+response = requests.get(url, auth=auth, headers=headers)
 response.json()
 ```
 
-> Response Example
+> Response Example - Get user and user group counts
 
 ```json
 {
@@ -63,6 +66,54 @@ response.json()
       "name": "default_tenant",
       "groups": 0,
       "users": 1
+    }
+  ],
+  "metadata": {
+    "pagination": {
+      "total": 1,
+      "offset": 0,
+      "size": 0
+    }
+  }
+}
+```
+
+> Request Example - Get user and user group details
+
+```shell
+# Get user and user group details
+$ curl -X GET \
+    -H "Tenant: default_tenant" \
+    -u <user>:<password> \
+    "http://<manager-ip>/api/v3.1/tenants?_get_data=true"
+```
+
+```python
+# Using Cloudify client
+client.tenants.list(_get_data=True)
+
+# Using requests
+url = 'http://<manager-ip>/api/v3.1/tenants?_get_data=true'
+response = requests.get(url, auth=auth, headers=headers)
+response.json()
+```
+
+> Response Example - Get user and user group details
+
+```json
+{
+  "items": [
+    {
+      "name": "default_tenant",
+      "groups": {},
+      "users": {
+        "admin": {
+          "tenant-role": "user",
+          "roles": [
+            "user"
+          ]
+        }
+      }
     }
   ],
   "metadata": {

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -21,8 +21,8 @@ client = CloudifyClient(
 import requests
 from requests.auth import HTTPBasicAuth
 
-headers = {'Tenant': '<tenant-name>'}
-auth = HTTPBasicAuth(<user>, <password>)
+headers = {'Tenant': '<tenant_name>'}
+auth = HTTPBasicAuth('<username>', '<password>')
 ```
 
 The Tenant resource is a logical component that represents a closed environment with its own resources.
@@ -43,7 +43,7 @@ Attribute | Type | Description
 ```shell
 $ curl -X GET \
     -H "Tenant: default_tenant" \
-    -u <user>:<password> \
+    -u <username>:<password> \
     "http://<manager-ip>/api/v3.1/tenants"
 ```
 
@@ -83,7 +83,7 @@ response.json()
 ```shell
 $ curl -X GET \
     -H "Tenant: default_tenant" \
-    -u <user>:<password> \
+    -u <username>:<password> \
     "http://<manager-ip>/api/v3.1/tenants?_get_data=true"
 ```
 
@@ -142,8 +142,8 @@ Field | Type | Description
 ```shell
 $ curl -X GET \
     -H "Tenant: default_tenant" \
-    -u <user>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants/{tenant-name}"
+    -u <username>:<password> \
+    "http://<manager-ip>/api/v3.1/tenants/{tenant_name}"
 ```
 
 ```python
@@ -151,7 +151,7 @@ $ curl -X GET \
 client.tenants.get('default_tenant')
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/<tenant-name>'
+url = 'http://<manager-ip>/api/v3.1/tenants/<tenant_name>'
 response = requests.get(url, auth=auth, headers=headers)
 response.json()
 ```
@@ -171,8 +171,8 @@ response.json()
 ```shell
 $ curl -X GET \
     -H "Tenant: default_tenant" \
-    -u <user>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants/{tenant-name}?_get_data=true"
+    -u <username>:<password> \
+    "http://<manager-ip>/api/v3.1/tenants/{tenant_name}?_get_data=true"
 ```
 
 ```python
@@ -180,7 +180,7 @@ $ curl -X GET \
 client.tenants.get('default_tenant', _get_data=True)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/<tenant-name>?_get_data=true'
+url = 'http://<manager-ip>/api/v3.1/tenants/<tenant_name>?_get_data=true'
 response = requests.get(url, auth=auth, headers=headers)
 response.json()
 ```
@@ -202,12 +202,12 @@ response.json()
 }
 ```
 
-`GET "{manager-ip}/api/v3.1/tenants?name={tenant-name}"`
+`GET "{manager-ip}/api/v3.1/tenants?name={tenant_name}"`
 
 Retrieves a specific tenant.
 
 ### URI Parameters
-* `tenant-name`: The name of the tenant to retrieve.
+* `tenant_name`: The name of the tenant to retrieve.
 
 ### Response
 A `Tenant` resource.
@@ -221,17 +221,17 @@ A `Tenant` resource.
 
 ```shell
 $ curl -X POST \
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants/<new-tenant-name>"
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    "http://<manager-ip>/api/v3.1/tenants/<new_tenant_name>"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.create(<new-tenant-name>)
+client.tenants.create('<new_tenant_name>')
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/<new-tenant-name>'
+url = 'http://<manager-ip>/api/v3.1/tenants/<new_tenant_name>'
 response = requests.post(url, auth=auth, headers=headers)
 response.json()
 ```
@@ -240,7 +240,7 @@ response.json()
 
 ```json
 {
-    "name": "<new-tenant-name>",
+    "name": "<new_tenant_name>",
     "groups": 0,
     "users": 0
 }
@@ -251,17 +251,17 @@ response.json()
 
 ```shell
 $ curl -X POST \
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants/<new-tenant-name>?_get_data=true"
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    "http://<manager-ip>/api/v3.1/tenants/<new_tenant_name>?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.create(<new-tenant-name>, _get_data=True)
+client.tenants.create('<new_tenant_name>', _get_data=True)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/<new-tenant-name>?_get_data=true'
+url = 'http://<manager-ip>/api/v3.1/tenants/<new_tenant_name>?_get_data=true'
 response = requests.post(url, auth=auth, headers=headers)
 response.json()
 ```
@@ -270,17 +270,17 @@ response.json()
 
 ```json
 {
-    "name": "<new-tenant-name>",
+    "name": "<new_tenant_name>",
     "groups": {},
     "users": {}
 }
 ```
-`POST "{manager-ip}/api/v3.1/tenants/{new-tenant-name}"`
+`POST "{manager-ip}/api/v3.1/tenants/{new_tenant_name}"`
 
 Creates a tenant.
 
 ### URI Parameters
-* `new-tenant-name`: The name of the tenant to create.
+* `new_tenant_name`: The name of the tenant to create.
 
 ### Response
 A `Tenant` resource.
@@ -295,17 +295,17 @@ A `Tenant` resource.
 
 ```shell
 $ curl -X DELETE \
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants/<tenant-name-to-delete>"
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    "http://<manager-ip>/api/v3.1/tenants/<tenant_name_to_delete>"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.delete(<tenant-name-to-delete>)
+client.tenants.delete('<tenant_name_to_delete>')
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/<tenant-name-to-delete>'
+url = 'http://<manager-ip>/api/v3.1/tenants/<tenant_name-to-delete>'
 response = requests.delete(url, auth=auth, headers=headers)
 response.json()
 
@@ -315,7 +315,7 @@ response.json()
 
 ```json
 {
-    "name": "tenant-name-to-delete",
+    "name": "tenant_name_to_delete",
     "groups": 0,
     "users": 0
 }
@@ -325,17 +325,17 @@ response.json()
 
 ```shell
 $ curl -X DELETE \
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants/<tenant-name-to-delete>?_get_data=true"
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    "http://<manager-ip>/api/v3.1/tenants/<tenant_name_to_delete>?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.delete(<tenant-name-to-delete>, _get_data=True)
+client.tenants.delete('<tenant_name_to_delete>', _get_data=True)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/<tenant-name-to-delete>?_get_data=true'
+url = 'http://<manager-ip>/api/v3.1/tenants/<tenant_name_to_delete>?_get_data=true'
 response = requests.delete(url, auth=auth, headers=headers)
 response.json()
 
@@ -345,17 +345,17 @@ response.json()
 
 ```json
 {
-    "name": "tenant-name-to-delete",
+    "name": "tenant_name_to_delete",
     "groups": {},
     "users": {}
 }
 ```
-`DELETE "{manager-ip}/api/v3.1/tenants/{tenant-name-to-delete}"`
+`DELETE "{manager-ip}/api/v3.1/tenants/{tenant_name_to_delete}"`
 
 Delete a tenant.
 
 ### URI Parameters
-* `tenant-name-to-delete`: The name of the tenant to delete.
+* `tenant_name_to_delete`: The name of the tenant to delete.
 
 ### Response
 A `Tenant` resource.
@@ -371,22 +371,22 @@ A `Tenant` resource.
 ```shell
 $ curl -X PUT \
     -H "Content-Type: application/json" \
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    -d '{"username": <user-name>, "tenant_name": <tenant-name>, "role": <role_name>}' \
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    -d '{"username": "<username>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
     "http://<manager-ip>/api/v3.1/tenants/users"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.add_user(<user-name>, <tenant-name>, <role>)
+client.tenants.add_user('<username>', '<tenant_name>', '<role_name>')
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/users'
 payload = {
-    'tenant_name': <tenant-name>,
-    'username': <user>,
-    'role': <role_name>,
+    'tenant_name': '<tenant_name>',
+    'username': '<username>',
+    'role': '<role_name>',
 }
 response = requests.get(url, auth=auth, headers=headers, json=payload)
 response.json()
@@ -396,7 +396,7 @@ response.json()
 
 ```json
 {
-    "name": "<tenant-name>",
+    "name": "<tenant_name>",
     "groups": 0,
     "users": 1
 }
@@ -407,22 +407,22 @@ response.json()
 ```shell
 $ curl -X PUT \
     -H "Content-Type: application/json" \
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    -d '{"username": <user-name>, "tenant_name": <tenant-name>, "role": <role_name>}' \
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    -d '{"username": <username>, "tenant_name": <tenant_name>, "role": <role_name>}' \
     "http://<manager-ip>/api/v3.1/tenants/users?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.add_user(<user-name>, <tenant-name>, <role>)
+client.tenants.add_user('<username>', '<tenant_name>', '<role_name>', _get_data=True)
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/users?_get_data=true'
 payload = {
-    'tenant_name': <tenant-name>,
-    'username': <user>,
-    'role': <role_name>,
+    'tenant_name': '<tenant_name>',
+    'username': '<username>',
+    'role': '<role_name>',
 }
 response = requests.get(url, auth=auth, headers=headers, json=payload, _get_data=True)
 response.json()
@@ -432,13 +432,13 @@ response.json()
 
 ```json
 {
-  "name": "<tenant-name>",
+  "name": "<tenant_name>",
   "groups": {},
   "users": {
-    "<user>": {
-      "tenant-role": "<role>",
+    "<username>": {
+      "tenant-role": "<role_name>",
       "roles": [
-        "<role>"
+        "<role_name>"
       ]
     }
   }
@@ -469,22 +469,22 @@ A `Tenant` resource.
 ```shell
 $ curl -X PATCH \
     -H "Content-Type: application/json"
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    -d '{"username": <user-name>, "tenant_name": <tenant-name>, "role": <role_name>}' \
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    -d '{"username": "<username>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
      "http://<manager-ip>/api/v3.1/tenants/users"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.update_user(<user-name>, <tenant-name>, <role_name>)
+client.tenants.update_user('<username>', '<tenant_name>', '<role_name>')
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/users'
 payload = {
-    'tenant_name': <tenant-name>,
-    'username': <user>,
-    'role': <role_name>,
+    'tenant_name': '<tenant_name>',
+    'username': '<username>',
+    'role': '<role_name>',
 }
 response = requests.patch(url, auth=auth, headers=headers, json=payload)
 response.json()
@@ -494,7 +494,7 @@ response.json()
 
 ```json
 {
-    "name": "tenant-name",
+    "name": "tenant_name",
     "groups": 0,
     "users": 1
 }
@@ -505,22 +505,22 @@ response.json()
 ```shell
 $ curl -X PATCH \
     -H "Content-Type: application/json"
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    -d '{"username": <user-name>, "tenant_name": <tenant-name>, "role": <role_name>}' \
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    -d '{"username": <username>, "tenant_name": <tenant_name>, "role": <role_name>}' \
      "http://<manager-ip>/api/v3.1/tenants/users?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.update_user(<user-name>, <tenant-name>, <role_name>, _get_data=True)
+client.tenants.update_user(<username>, <tenant_name>, <role_name>, _get_data=True)
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/users?_get_data=true'
 payload = {
-    'tenant_name': <tenant-name>,
-    'username': <user>,
-    'role': <role_name>,
+    'tenant_name': '<tenant_name>',
+    'username': '<username>',
+    'role': '<role_name>',
 }
 response = requests.patch(url, auth=auth, headers=headers, json=payload)
 response.json()
@@ -530,13 +530,13 @@ response.json()
 
 ```json
 {
-  "name": "<tenant-name>",
+  "name": "<tenant_name>",
   "groups": {},
   "users": {
     "my-user": {
-      "tenant-role": "<role>",
+      "tenant-role": "<role_name>",
       "roles": [
-        "<role>"
+        "<role_name>"
       ]
     }
   }
@@ -565,21 +565,21 @@ A `Tenant` resource.
 ```shell
 $ curl -X DELETE \
     -H "Content-Type: application/json"
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    -d '{"username": <user-name>, "tenant_name": <tenant-name>}' \
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    -d '{"username": "<username>", "tenant_name": "<tenant_name>"}' \
      "http://<manager-ip>/api/v3.1/tenants/users"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.remove_user(<user-name>, <tenant-name>)
+client.tenants.remove_user('<username>', '<tenant_name>')
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/users'
 payload = {
-    'tenant_name': <tenant-name>,
-    'username': <user>,
+    'tenant_name': '<tenant_name>',
+    'username': '<username>',
 }
 response = requests.delete(url, auth=auth, headers=headers, json=payload)
 response.json()
@@ -589,7 +589,7 @@ response.json()
 
 ```json
 {
-    "name": "tenant-name",
+    "name": "tenant_name",
     "groups": 0,
     "users": 0
 }
@@ -600,21 +600,21 @@ response.json()
 ```shell
 $ curl -X DELETE \
     -H "Content-Type: application/json"
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    -d '{"username": <user-name>, "tenant_name": <tenant-name>}' \
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    -d '{"username": "<username>", "tenant_name": "<tenant_name>"}' \
      "http://<manager-ip>/api/v3.1/tenants/users?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.remove_user(<user-name>, <tenant-name>, _get_data=True)
+client.tenants.remove_user(<username>, <tenant_name>, _get_data=True)
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/users?_get_data=true'
 payload = {
-    'tenant_name': <tenant-name>,
-    'username': <user>,
+    'tenant_name': '<tenant_name>',
+    'username': '<username>',
 }
 response = requests.delete(url, auth=auth, headers=headers, json=payload)
 response.json()
@@ -624,7 +624,7 @@ response.json()
 
 ```json
 {
-    "name": "tenant-name",
+    "name": "tenant_name",
     "groups": {},
     "users": {}
 }
@@ -654,23 +654,23 @@ A `Tenant` resource.
 ```shell
 $ curl -X PUT \
     -H "Content-Type: application/json" \
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    -d '{"group_name": <group-name>, "tenant_name": <tenant-name>, "role": <role-name>}' \
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    -d '{"group_name": "<group_name>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
     "http://<manager-ip>/api/v3.1/tenants/user-groups"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.add_user_group(<group-name>, <tenant-name>, <role>)
+client.tenants.add_user_group('<group_name>', '<tenant_name>', '<role_name>')
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/user-groups'
-headers = {'Tenant': '<tenant-name>'}
+headers = {'Tenant': '<tenant_name>'}
 payload = {
-    'tenant_name': <tenant-name>,
-    'group_name': <user>,
-    'role': <role_name>,
+    'tenant_name': '<tenant_name>',
+    'group_name': '<group_name>',
+    'role': '<role_name>',
 }
 response = requests.put(url, auth=auth, headers=headers, json=payload)
 response.json()
@@ -680,7 +680,7 @@ response.json()
 
 ```json
 {
-    "name": "tenant-name",
+    "name": "tenant_name",
     "groups": 1,
     "users": 0
 }
@@ -691,23 +691,23 @@ response.json()
 ```shell
 $ curl -X PUT \
     -H "Content-Type: application/json" \
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    -d '{"group_name": <group-name>, "tenant_name": <tenant-name>, "role": <role-name>}' \
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    -d '{"group_name": "<group_name>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
     "http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.add_user_group(<group-name>, <tenant-name>, <role>, _get_data=True)
+client.tenants.add_user_group('<group_name>', '<tenant_name>', '<role_name>', _get_data=True)
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true'
-headers = {'Tenant': '<tenant-name>'}
+headers = {'Tenant': '<tenant_name>'}
 payload = {
-    'tenant_name': <tenant-name>,
-    'group_name': <group-name>,
-    'role': <role_name>,
+    'tenant_name': '<tenant_name>',
+    'group_name': '<group_name>',
+    'role': '<role_name>',
 }
 response = requests.put(url, auth=auth, headers=headers, json=payload)
 response.json()
@@ -717,9 +717,9 @@ response.json()
 
 ```json
 {
-  "name": "<tenant-name>",
+  "name": "<tenant_name>",
   "groups": {
-    "<group-name>": "<role>"
+    "<group_name>": "<role_name>"
   },
   "users": {}
 }
@@ -749,22 +749,22 @@ A `Tenant` resource.
 ```shell
 $ curl -X PATCH \
     -H "Content-Type: application/json"
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    -d '{"username": <user-name>, "group_name": <group-name>, "role": <role-name>}' \
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    -d '{"username": "<username>", "group_name": "<group_name>", "role": "<role_name>"}' \
      "http://<manager-ip>/api/v3.1/tenants/user-groups"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.update_user_group(<group-name>, <tenant-name>, <role-name>)
+client.tenants.update_user_group('<group_name>', '<tenant_name>', '<role_name>')
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/user-groups'
 payload = {
-    'tenant_name': <tenant-name>,
-    'group_name': <group-name>,
-    'role': <role-name>,
+    'tenant_name': '<tenant_name>',
+    'group_name': '<group_name>',
+    'role': '<role_name>',
 }
 response = requests.patch(url, auth=auth, headers=headers, json=payload)
 response.json()
@@ -774,7 +774,7 @@ response.json()
 
 ```json
 {
-    "name": "tenant-name",
+    "name": "tenant_name",
     "groups": 1,
     "users": 0
 }
@@ -785,22 +785,22 @@ response.json()
 ```shell
 $ curl -X PATCH \
     -H "Content-Type: application/json"
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    -d '{"username": <user-name>, "group_name": <group-name>, "role": <role-name>}' \
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    -d '{"username": "<username>", "group_name": "<group_name>", "role": "<role_name>"}' \
      "http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.update_user_group(<group-name>, <tenant-name>, <role-name>, _get_data=True)
+client.tenants.update_user_group('<group_name>', '<tenant_name>', '<role_name>', _get_data=True)
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true'
 payload = {
-    'tenant_name': <tenant-name>,
-    'group_name': <group-name>,
-    'role': <role-name>,
+    'tenant_name': '<tenant_name>',
+    'group_name': '<group_name>',
+    'role': '<role_name>',
 }
 response = requests.patch(url, auth=auth, headers=headers, json=payload)
 response.json()
@@ -810,9 +810,9 @@ response.json()
 
 ```json
 {
-  "name": "<tenant-name>",
+  "name": "<tenant_name>",
   "groups": {
-    "<group-name>": "<role>"
+    "<group_name>": "<role_name>"
   },
   "users": {}
 }
@@ -841,21 +841,21 @@ A `Tenant` resource.
 ```shell
 $ curl -X DELETE \
     -H "Content-Type: application/json" \
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    -d '{"group_name": <group-name>, "tenant_name": <tenant-name>}' \
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    -d '{"group_name": "<group_name>", "tenant_name": "<tenant_name>"}' \
     "http://<manager-ip>/api/v3.1/tenants/user-groups"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.remove_user_group(<group-name>, <tenant-name>)
+client.tenants.remove_user_group('<group_name>', '<tenant_name>')
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/user-groups'
 payload = {
-    'tenant_name': <tenant-name>,
-    'group_name': <user>,
+    'tenant_name': '<tenant_name>',
+    'group_name': '<group_name>',
 }
 response = requests.delete(url, auth=auth, headers=headers, json=payload)
 response.json()
@@ -865,7 +865,7 @@ response.json()
 
 ```json
 {
-    "name": "tenant-name",
+    "name": "tenant_name",
     "groups": 0,
     "users": 0
 }
@@ -876,22 +876,22 @@ response.json()
 ```shell
 $ curl -X DELETE \
     -H "Content-Type: application/json" \
-    -H "Tenant: <tenant-name>" \
-    -u <user>:<password> \
-    -d '{"group_name": <group-name>, "tenant_name": <tenant-name>}' \
+    -H "Tenant: <tenant_name>" \
+    -u <username>:<password> \
+    -d '{"group_name": "<group_name>", "tenant_name": "<tenant_name>"}' \
     "http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.remove_user_group(<group-name>, <tenant-name>, _get_data=True)
+client.tenants.remove_user_group('<group_name>', '<tenant_name>', _get_data=True)
 
 # Using requests
 url = 'http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true'
-headers = {'Tenant': '<tenant-name>'}
+headers = {'Tenant': '<tenant_name>'}
 payload = {
-    'tenant_name': <tenant-name>,
-    'group_name': <user>,
+    'tenant_name': '<tenant_name>',
+    'group_name': '<group_name>',
 }
 response = requests.delete(url, auth=auth, headers=headers, json=payload)
 response.json()
@@ -901,7 +901,7 @@ response.json()
 
 ```json
 {
-    "name": "tenant-name",
+    "name": "tenant_name",
     "groups": {},
     "users": {}
 }

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -9,14 +9,6 @@ This section describes API features that are part of the Cloudify premium editio
 > `Note`
 
 ```python
-# Include this code when using the Cloudify client
-from cloudify_rest_client import CloudifyClient
-client = CloudifyClient(
-        host='<manager-ip>',
-        username='<manager-username>',
-        password='<manager-password>',
-        tenant='<manager-tenant>')
-
 # Include this code when using python requests
 import requests
 from requests.auth import HTTPBasicAuth
@@ -44,15 +36,22 @@ Attribute | Type | Description
 $ curl -X GET \
     -H "Tenant: default_tenant" \
     -u <username>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants"
+    "http://<manager_ip>/api/v3.1/tenants"
 ```
 
 ```python
 # Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
 client.tenants.list()
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants'
+url = 'http://<manager_ip>/api/v3.1/tenants'
 response = requests.get(url, auth=auth, headers=headers)
 response.json()
 ```
@@ -84,15 +83,22 @@ response.json()
 $ curl -X GET \
     -H "Tenant: default_tenant" \
     -u <username>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants?_get_data=true"
+    "http://<manager_ip>/api/v3.1/tenants?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
 client.tenants.list(_get_data=True)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants?_get_data=true'
+url = 'http://<manager_ip>/api/v3.1/tenants?_get_data=true'
 response = requests.get(url, auth=auth, headers=headers)
 response.json()
 ```
@@ -125,7 +131,7 @@ response.json()
 }
 ```
 
-`GET "{manager-ip}/api/v3.1/tenants"`
+`GET "{manager_ip}/api/v3.1/tenants"`
 
 List all tenants.
 
@@ -143,15 +149,22 @@ Field | Type | Description
 $ curl -X GET \
     -H "Tenant: default_tenant" \
     -u <username>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants/{tenant_name}"
+    "http://<manager_ip>/api/v3.1/tenants/{tenant_name}"
 ```
 
 ```python
 # Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
 client.tenants.get('default_tenant')
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/<tenant_name>'
+url = 'http://<manager_ip>/api/v3.1/tenants/<tenant_name>'
 response = requests.get(url, auth=auth, headers=headers)
 response.json()
 ```
@@ -172,15 +185,22 @@ response.json()
 $ curl -X GET \
     -H "Tenant: default_tenant" \
     -u <username>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants/{tenant_name}?_get_data=true"
+    "http://<manager_ip>/api/v3.1/tenants/{tenant_name}?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
 client.tenants.get('default_tenant', _get_data=True)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/<tenant_name>?_get_data=true'
+url = 'http://<manager_ip>/api/v3.1/tenants/<tenant_name>?_get_data=true'
 response = requests.get(url, auth=auth, headers=headers)
 response.json()
 ```
@@ -202,7 +222,7 @@ response.json()
 }
 ```
 
-`GET "{manager-ip}/api/v3.1/tenants?name={tenant_name}"`
+`GET "{manager_ip}/api/v3.1/tenants?name={tenant_name}"`
 
 Retrieves a specific tenant.
 
@@ -223,15 +243,22 @@ A `Tenant` resource.
 $ curl -X POST \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants/<new_tenant_name>"
+    "http://<manager_ip>/api/v3.1/tenants/<new_tenant_name>"
 ```
 
 ```python
 # Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
 client.tenants.create('<new_tenant_name>')
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/<new_tenant_name>'
+url = 'http://<manager_ip>/api/v3.1/tenants/<new_tenant_name>'
 response = requests.post(url, auth=auth, headers=headers)
 response.json()
 ```
@@ -253,15 +280,22 @@ response.json()
 $ curl -X POST \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants/<new_tenant_name>?_get_data=true"
+    "http://<manager_ip>/api/v3.1/tenants/<new_tenant_name>?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
 client.tenants.create('<new_tenant_name>', _get_data=True)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/<new_tenant_name>?_get_data=true'
+url = 'http://<manager_ip>/api/v3.1/tenants/<new_tenant_name>?_get_data=true'
 response = requests.post(url, auth=auth, headers=headers)
 response.json()
 ```
@@ -275,7 +309,7 @@ response.json()
     "users": {}
 }
 ```
-`POST "{manager-ip}/api/v3.1/tenants/{new_tenant_name}"`
+`POST "{manager_ip}/api/v3.1/tenants/{new_tenant_name}"`
 
 Creates a tenant.
 
@@ -297,15 +331,22 @@ A `Tenant` resource.
 $ curl -X DELETE \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants/<tenant_name_to_delete>"
+    "http://<manager_ip>/api/v3.1/tenants/<tenant_name_to_delete>"
 ```
 
 ```python
 # Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
 client.tenants.delete('<tenant_name_to_delete>')
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/<tenant_name-to-delete>'
+url = 'http://<manager_ip>/api/v3.1/tenants/<tenant_name-to-delete>'
 response = requests.delete(url, auth=auth, headers=headers)
 response.json()
 
@@ -327,15 +368,22 @@ response.json()
 $ curl -X DELETE \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
-    "http://<manager-ip>/api/v3.1/tenants/<tenant_name_to_delete>?_get_data=true"
+    "http://<manager_ip>/api/v3.1/tenants/<tenant_name_to_delete>?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
 client.tenants.delete('<tenant_name_to_delete>', _get_data=True)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/<tenant_name_to_delete>?_get_data=true'
+url = 'http://<manager_ip>/api/v3.1/tenants/<tenant_name_to_delete>?_get_data=true'
 response = requests.delete(url, auth=auth, headers=headers)
 response.json()
 
@@ -350,7 +398,7 @@ response.json()
     "users": {}
 }
 ```
-`DELETE "{manager-ip}/api/v3.1/tenants/{tenant_name_to_delete}"`
+`DELETE "{manager_ip}/api/v3.1/tenants/{tenant_name_to_delete}"`
 
 Delete a tenant.
 
@@ -374,15 +422,26 @@ $ curl -X PUT \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
     -d '{"username": "<username>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
-    "http://<manager-ip>/api/v3.1/tenants/users"
+    "http://<manager_ip>/api/v3.1/tenants/users"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.add_user('<username>', '<tenant_name>', '<role_name>')
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
+client.tenants.add_user(
+    '<username>',
+    '<tenant_name>',
+    '<role_name>',
+)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/users'
+url = 'http://<manager_ip>/api/v3.1/tenants/users'
 payload = {
     'tenant_name': '<tenant_name>',
     'username': '<username>',
@@ -410,15 +469,27 @@ $ curl -X PUT \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
     -d '{"username": <username>, "tenant_name": <tenant_name>, "role": <role_name>}' \
-    "http://<manager-ip>/api/v3.1/tenants/users?_get_data=true"
+    "http://<manager_ip>/api/v3.1/tenants/users?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.add_user('<username>', '<tenant_name>', '<role_name>', _get_data=True)
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
+client.tenants.add_user(
+    '<username>',
+    '<tenant_name>',
+    '<role_name>',
+    _get_data=True,
+)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/users?_get_data=true'
+url = 'http://<manager_ip>/api/v3.1/tenants/users?_get_data=true'
 payload = {
     'tenant_name': '<tenant_name>',
     'username': '<username>',
@@ -445,7 +516,7 @@ response.json()
 }
 ```
 
-`PUT "{manager-ip}/api/v3.1/tenants/users"`
+`PUT "{manager_ip}/api/v3.1/tenants/users"`
 
 Add a user to a tenant.
 
@@ -472,15 +543,26 @@ $ curl -X PATCH \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
     -d '{"username": "<username>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
-     "http://<manager-ip>/api/v3.1/tenants/users"
+     "http://<manager_ip>/api/v3.1/tenants/users"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.update_user('<username>', '<tenant_name>', '<role_name>')
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
+client.tenants.update_user(
+    '<username>',
+    '<tenant_name>',
+    '<role_name>',
+)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/users'
+url = 'http://<manager_ip>/api/v3.1/tenants/users'
 payload = {
     'tenant_name': '<tenant_name>',
     'username': '<username>',
@@ -508,15 +590,27 @@ $ curl -X PATCH \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
     -d '{"username": <username>, "tenant_name": <tenant_name>, "role": <role_name>}' \
-     "http://<manager-ip>/api/v3.1/tenants/users?_get_data=true"
+     "http://<manager_ip>/api/v3.1/tenants/users?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.update_user(<username>, <tenant_name>, <role_name>, _get_data=True)
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
+client.tenants.update_user(
+    '<username>',
+    '<tenant_name>',
+    '<role_name>',
+    _get_data=True,
+)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/users?_get_data=true'
+url = 'http://<manager_ip>/api/v3.1/tenants/users?_get_data=true'
 payload = {
     'tenant_name': '<tenant_name>',
     'username': '<username>',
@@ -542,7 +636,7 @@ response.json()
   }
 }
 ```
-`PATCH "{manager-ip}/api/v3.1/tenants/users"`
+`PATCH "{manager_ip}/api/v3.1/tenants/users"`
 
 Update a user in a tenant.
 
@@ -568,15 +662,22 @@ $ curl -X DELETE \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
     -d '{"username": "<username>", "tenant_name": "<tenant_name>"}' \
-     "http://<manager-ip>/api/v3.1/tenants/users"
+     "http://<manager_ip>/api/v3.1/tenants/users"
 ```
 
 ```python
 # Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
 client.tenants.remove_user('<username>', '<tenant_name>')
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/users'
+url = 'http://<manager_ip>/api/v3.1/tenants/users'
 payload = {
     'tenant_name': '<tenant_name>',
     'username': '<username>',
@@ -603,15 +704,26 @@ $ curl -X DELETE \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
     -d '{"username": "<username>", "tenant_name": "<tenant_name>"}' \
-     "http://<manager-ip>/api/v3.1/tenants/users?_get_data=true"
+     "http://<manager_ip>/api/v3.1/tenants/users?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.remove_user(<username>, <tenant_name>, _get_data=True)
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
+client.tenants.remove_user(
+    '<username>',
+    '<tenant_name>',
+    _get_data=True,
+)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/users?_get_data=true'
+url = 'http://<manager_ip>/api/v3.1/tenants/users?_get_data=true'
 payload = {
     'tenant_name': '<tenant_name>',
     'username': '<username>',
@@ -629,7 +741,7 @@ response.json()
     "users": {}
 }
 ```
-`DELETE "{manager-ip}/api/v3.1/tenants/users"`
+`DELETE "{manager_ip}/api/v3.1/tenants/users"`
 
 Delete a user from a tenant.
 
@@ -657,15 +769,26 @@ $ curl -X PUT \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
     -d '{"group_name": "<group_name>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
-    "http://<manager-ip>/api/v3.1/tenants/user-groups"
+    "http://<manager_ip>/api/v3.1/tenants/user-groups"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.add_user_group('<group_name>', '<tenant_name>', '<role_name>')
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
+client.tenants.add_user_group(
+    '<group_name>',
+    '<tenant_name>',
+    '<role_name>',
+)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/user-groups'
+url = 'http://<manager_ip>/api/v3.1/tenants/user-groups'
 headers = {'Tenant': '<tenant_name>'}
 payload = {
     'tenant_name': '<tenant_name>',
@@ -694,15 +817,27 @@ $ curl -X PUT \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
     -d '{"group_name": "<group_name>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
-    "http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true"
+    "http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.add_user_group('<group_name>', '<tenant_name>', '<role_name>', _get_data=True)
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
+client.tenants.add_user_group(
+    '<group_name>',
+    '<tenant_name>',
+    '<role_name>',
+    _get_data=True,
+)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true'
+url = 'http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true'
 headers = {'Tenant': '<tenant_name>'}
 payload = {
     'tenant_name': '<tenant_name>',
@@ -725,7 +860,7 @@ response.json()
 }
 ```
 
-`PUT "{manager-ip}/api/v3.1/tenants/user-groups"`
+`PUT "{manager_ip}/api/v3.1/tenants/user-groups"`
 
 Add a user group to a tenant.
 
@@ -752,15 +887,26 @@ $ curl -X PATCH \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
     -d '{"username": "<username>", "group_name": "<group_name>", "role": "<role_name>"}' \
-     "http://<manager-ip>/api/v3.1/tenants/user-groups"
+     "http://<manager_ip>/api/v3.1/tenants/user-groups"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.update_user_group('<group_name>', '<tenant_name>', '<role_name>')
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
+client.tenants.update_user_group(
+    '<group_name>',
+    '<tenant_name>',
+    '<role_name>',
+)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/user-groups'
+url = 'http://<manager_ip>/api/v3.1/tenants/user-groups'
 payload = {
     'tenant_name': '<tenant_name>',
     'group_name': '<group_name>',
@@ -788,15 +934,27 @@ $ curl -X PATCH \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
     -d '{"username": "<username>", "group_name": "<group_name>", "role": "<role_name>"}' \
-     "http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true"
+     "http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.update_user_group('<group_name>', '<tenant_name>', '<role_name>', _get_data=True)
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
+client.tenants.update_user_group(
+    '<group_name>',
+    '<tenant_name>',
+    '<role_name>',
+    _get_data=True,
+)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true'
+url = 'http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true'
 payload = {
     'tenant_name': '<tenant_name>',
     'group_name': '<group_name>',
@@ -818,7 +976,7 @@ response.json()
 }
 ```
 
-`PATCH "{manager-ip}/api/v3.1/tenants/user-groups"`
+`PATCH "{manager_ip}/api/v3.1/tenants/user-groups"`
 
 Update a user group in a tenant.
 
@@ -844,15 +1002,22 @@ $ curl -X DELETE \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
     -d '{"group_name": "<group_name>", "tenant_name": "<tenant_name>"}' \
-    "http://<manager-ip>/api/v3.1/tenants/user-groups"
+    "http://<manager_ip>/api/v3.1/tenants/user-groups"
 ```
 
 ```python
 # Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
 client.tenants.remove_user_group('<group_name>', '<tenant_name>')
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/user-groups'
+url = 'http://<manager_ip>/api/v3.1/tenants/user-groups'
 payload = {
     'tenant_name': '<tenant_name>',
     'group_name': '<group_name>',
@@ -879,15 +1044,26 @@ $ curl -X DELETE \
     -H "Tenant: <tenant_name>" \
     -u <username>:<password> \
     -d '{"group_name": "<group_name>", "tenant_name": "<tenant_name>"}' \
-    "http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true"
+    "http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true"
 ```
 
 ```python
 # Using Cloudify client
-client.tenants.remove_user_group('<group_name>', '<tenant_name>', _get_data=True)
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+    host='<manager_ip>',
+    username='<manager_username>',
+    password='<manager_password>',
+    tenant='<manager_tenant>',
+)
+client.tenants.remove_user_group(
+    '<group_name>',
+    '<tenant_name>',
+    _get_data=True,
+)
 
 # Using requests
-url = 'http://<manager-ip>/api/v3.1/tenants/user-groups?_get_data=true'
+url = 'http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true'
 headers = {'Tenant': '<tenant_name>'}
 payload = {
     'tenant_name': '<tenant_name>',
@@ -906,7 +1082,7 @@ response.json()
     "users": {}
 }
 ```
-`DELETE "{manager-ip}/api/v3.1/tenants/user-groups"`
+`DELETE "{manager_ip}/api/v3.1/tenants/user-groups"`
 
 Delete a user group from a tenant.
 

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -138,7 +138,7 @@ Field | Type | Description
 
 ## Get Tenant
 
-> Request Example
+> Request Example - Get user and user group counts
 
 ```shell
 $ curl -X GET \
@@ -156,18 +156,53 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 url = 'http://<manager-ip>/api/v3.1/tenants/<tenant-name>'
-headers = {'Tenant': '<tenant-name>'}
-response = requests.get(url, auth=HTTPBasicAuth(<user>, <password>), headers=headers)
+response = requests.get(url, auth=auth, headers=headers)
 response.json()
 ```
 
-> Response Example
+> Response Example - Get user and user group counts
 
 ```json
 {
     "name": "default_tenant",
     "groups": 0,
     "users": 1
+}
+```
+
+> Request Example - Get user and user group details
+
+```shell
+$ curl -X GET \
+    -H "Tenant: default_tenant" \
+    -u <user>:<password> \
+    "http://<manager-ip>/api/v3.1/tenants/{tenant-name}?_get_data=true"
+```
+
+```python
+# Using Cloudify client
+client.tenants.get('default_tenant', _get_data=True)
+
+# Using requests
+url = 'http://<manager-ip>/api/v3.1/tenants/<tenant-name>?_get_data=true'
+response = requests.get(url, auth=auth, headers=headers)
+response.json()
+```
+
+> Response Example - Get user and user group counts
+
+```json
+{
+  "name": "default_tenant",
+  "groups": {},
+  "users": {
+    "admin": {
+      "tenant-role": "user",
+      "roles": [
+        "user"
+      ]
+    }
+  }
 }
 ```
 

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -295,7 +295,7 @@ A `Tenant` resource.
 
 ## Delete Tenant
 
-> Request Example
+> Request Example - Get user and user group counts
 
 ```shell
 $ curl -X DELETE \
@@ -309,17 +309,13 @@ $ curl -X DELETE \
 client.tenants.delete(<tenant-name-to-delete>)
 
 # Using requests
-import requests
-from requests.auth import HTTPBasicAuth
-
 url = 'http://<manager-ip>/api/v3.1/tenants/<tenant-name-to-delete>'
-headers = {'Tenant': '<tenant-name>'}
-response = requests.delete(url, auth=HTTPBasicAuth(<user>, <password>), headers=headers)
+response = requests.delete(url, auth=auth, headers=headers)
 response.json()
 
 ```
 
-> Response Example
+> Response Example - Get user and user group counts
 
 ```json
 {
@@ -329,6 +325,35 @@ response.json()
 }
 ```
 
+> Request Example - Get user and user group details
+
+```shell
+$ curl -X DELETE \
+    -H "Tenant: <tenant-name>" \
+    -u <user>:<password> \
+    "http://<manager-ip>/api/v3.1/tenants/<tenant-name-to-delete>?_get_data=true"
+```
+
+```python
+# Using Cloudify client
+client.tenants.delete(<tenant-name-to-delete>, _get_data=True)
+
+# Using requests
+url = 'http://<manager-ip>/api/v3.1/tenants/<tenant-name-to-delete>?_get_data=true'
+response = requests.delete(url, auth=auth, headers=headers)
+response.json()
+
+```
+
+> Response Example - Get user and user group details
+
+```json
+{
+    "name": "tenant-name-to-delete",
+    "groups": {},
+    "users": {}
+}
+```
 `DELETE "{manager-ip}/api/v3.1/tenants/{tenant-name-to-delete}"`
 
 Delete a tenant.

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -168,7 +168,7 @@ client = CloudifyClient(
     password='<manager_password>',
     tenant='<manager_tenant>',
 )
-client.tenants.get('default_tenant')
+client.tenants.get('<tenant_name>')
 
 # Using requests
 import requests
@@ -189,7 +189,7 @@ response.json()
 
 ```json
 {
-    "name": "default_tenant",
+    "name": "<tenant_name>",
     "groups": 0,
     "users": 1
 }
@@ -213,7 +213,7 @@ client = CloudifyClient(
     password='<manager_password>',
     tenant='<manager_tenant>',
 )
-client.tenants.get('default_tenant', _get_data=True)
+client.tenants.get('<tenant_name>', _get_data=True)
 
 # Using requests
 import requests
@@ -234,7 +234,7 @@ response.json()
 
 ```json
 {
-  "name": "default_tenant",
+  "name": "<tenant_name>",
   "groups": {},
   "users": {
     "admin": {

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -151,9 +151,6 @@ $ curl -X GET \
 client.tenants.get('default_tenant')
 
 # Using requests
-import requests
-from requests.auth import HTTPBasicAuth
-
 url = 'http://<manager-ip>/api/v3.1/tenants/<tenant-name>'
 response = requests.get(url, auth=auth, headers=headers)
 response.json()
@@ -563,7 +560,7 @@ A `Tenant` resource.
 
 ## Remove User from Tenant
 
-> Request Example
+> Request Example - Get user and user group counts
 
 ```shell
 $ curl -X DELETE \
@@ -579,25 +576,16 @@ $ curl -X DELETE \
 client.tenants.remove_user(<user-name>, <tenant-name>)
 
 # Using requests
-import requests
-from requests.auth import HTTPBasicAuth
-
 url = 'http://<manager-ip>/api/v3.1/tenants/users'
-headers = {'Tenant': '<tenant-name>'}
 payload = {
     'tenant_name': <tenant-name>,
     'username': <user>,
 }
-response = requests.delete(
-    url,
-    auth=HTTPBasicAuth(<user>, <password>),
-    headers=headers,
-    json=payload,
-)
+response = requests.delete(url, auth=auth, headers=headers, json=payload)
 response.json()
 ```
 
-> Response Example
+> Response Example - Get user and user group counts
 
 ```json
 {
@@ -607,6 +595,40 @@ response.json()
 }
 ```
 
+> Request Example - Get user and user group details
+
+```shell
+$ curl -X DELETE \
+    -H "Content-Type: application/json"
+    -H "Tenant: <tenant-name>" \
+    -u <user>:<password> \
+    -d '{"username": <user-name>, "tenant_name": <tenant-name>}' \
+     "http://<manager-ip>/api/v3.1/tenants/users?_get_data=true"
+```
+
+```python
+# Using Cloudify client
+client.tenants.remove_user(<user-name>, <tenant-name>, _get_data=True)
+
+# Using requests
+url = 'http://<manager-ip>/api/v3.1/tenants/users?_get_data=true'
+payload = {
+    'tenant_name': <tenant-name>,
+    'username': <user>,
+}
+response = requests.delete(url, auth=auth, headers=headers, json=payload)
+response.json()
+```
+
+> Response Example - Get user and user group details
+
+```json
+{
+    "name": "tenant-name",
+    "groups": {},
+    "users": {}
+}
+```
 `DELETE "{manager-ip}/api/v3.1/tenants/users"`
 
 Delete a user from a tenant.
@@ -643,9 +665,6 @@ $ curl -X PUT \
 client.tenants.add_user_group(<group-name>, <tenant-name>, <role>)
 
 # Using requests
-import requests
-from requests.auth import HTTPBasicAuth
-
 url = 'http://<manager-ip>/api/v3.1/tenants/user-groups'
 headers = {'Tenant': '<tenant-name>'}
 payload = {
@@ -653,12 +672,7 @@ payload = {
     'group_name': <user>,
     'role': <role_name>,
 }
-response = requests.put(
-    url,
-    auth=HTTPBasicAuth(<user>, <password>),
-    headers=headers,
-    json=payload,
-)
+response = requests.put(url, auth=auth, headers=headers, json=payload)
 response.json()
 ```
 
@@ -707,9 +721,6 @@ $ curl -X PATCH \
 client.tenants.update_user_group(<group-name>, <tenant-name>, <role-name>)
 
 # Using requests
-import requests
-from requests.auth import HTTPBasicAuth
-
 url = 'http://<manager-ip>/api/v3.1/tenants/user-groups'
 headers = {'Tenant': '<tenant-name>'}
 payload = {
@@ -717,12 +728,7 @@ payload = {
     'group_name': <group-name>,
     'role': <role-name>,
 }
-response = requests.patch(
-    url,
-    auth=HTTPBasicAuth(<user>, <password>),
-    headers=headers,
-    json=payload,
-)
+response = requests.patch(url, auth=auth, headers=headers, json=payload)
 response.json()
 ```
 
@@ -770,21 +776,13 @@ $ curl -X DELETE \
 client.tenants.remove_user_group(<group-name>, <tenant-name>)
 
 # Using requests
-import requests
-from requests.auth import HTTPBasicAuth
-
 url = 'http://<manager-ip>/api/v3.1/tenants/user-groups'
 headers = {'Tenant': '<tenant-name>'}
 payload = {
     'tenant_name': <tenant-name>,
     'group_name': <user>,
 }
-response = requests.delete(
-    url,
-    auth=HTTPBasicAuth(<user>, <password>),
-    headers=headers,
-    json=payload,
-)
+response = requests.delete(url, auth=auth, headers=headers, json=payload)
 response.json()
 ```
 

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -482,7 +482,7 @@ $ curl -X PUT \
     -H "Content-Type: application/json" \
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    -d '{"username": "<username>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
+    -d '{"username": "<username_to_add>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
     "http://<manager_ip>/api/v3.1/tenants/users"
 ```
 
@@ -496,7 +496,7 @@ client = CloudifyClient(
     tenant='<manager_tenant>',
 )
 client.tenants.add_user(
-    '<username>',
+    '<username_to_add>',
     '<tenant_name>',
     '<role_name>',
 )
@@ -510,7 +510,7 @@ auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
 headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
-    'username': '<username>',
+    'username': '<username_to_add>',
     'role': '<role_name>',
 }
 response = requests.get(
@@ -539,7 +539,7 @@ $ curl -X PUT \
     -H "Content-Type: application/json" \
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    -d '{"username": <username>, "tenant_name": <tenant_name>, "role": <role_name>}' \
+    -d '{"username": <username_to_add>, "tenant_name": <tenant_name>, "role": <role_name>}' \
     "http://<manager_ip>/api/v3.1/tenants/users?_get_data=true"
 ```
 
@@ -553,7 +553,7 @@ client = CloudifyClient(
     tenant='<manager_tenant>',
 )
 client.tenants.add_user(
-    '<username>',
+    '<username_to_add>',
     '<tenant_name>',
     '<role_name>',
     _get_data=True,
@@ -568,7 +568,7 @@ auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
 headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
-    'username': '<username>',
+    'username': '<username_to_add>',
     'role': '<role_name>',
 }
 response = requests.get(
@@ -588,7 +588,7 @@ response.json()
   "name": "<tenant_name>",
   "groups": {},
   "users": {
-    "<username>": {
+    "<username_to_add>": {
       "tenant-role": "<role_name>",
       "roles": [
         "<role_name>"
@@ -606,7 +606,7 @@ Add a user to a tenant.
 
 Property | Type | Description
 --------- | ------- | -----------
-`username` | string | The user name to add to the tenant.
+`username_to_add` | string | The user name to add to the tenant.
 `tenant_name` | string | The name of the tenant to which to add the user.
 `role_name` | string | (Optional) The name of the role assigned to the user in the tenant. If not passed the default tenant role will be used.
 
@@ -624,7 +624,7 @@ $ curl -X PATCH \
     -H "Content-Type: application/json"
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    -d '{"username": "<username>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
+    -d '{"username": "<username_to_update>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
      "http://<manager_ip>/api/v3.1/tenants/users"
 ```
 
@@ -638,7 +638,7 @@ client = CloudifyClient(
     tenant='<manager_tenant>',
 )
 client.tenants.update_user(
-    '<username>',
+    '<username_to_update>',
     '<tenant_name>',
     '<role_name>',
 )
@@ -652,7 +652,7 @@ auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
 headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
-    'username': '<username>',
+    'username': '<username_to_update>',
     'role': '<role_name>',
 }
 response = requests.patch(
@@ -681,7 +681,7 @@ $ curl -X PATCH \
     -H "Content-Type: application/json"
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    -d '{"username": <username>, "tenant_name": <tenant_name>, "role": <role_name>}' \
+    -d '{"username": <username_to_update>, "tenant_name": <tenant_name>, "role": <role_name>}' \
      "http://<manager_ip>/api/v3.1/tenants/users?_get_data=true"
 ```
 
@@ -695,7 +695,7 @@ client = CloudifyClient(
     tenant='<manager_tenant>',
 )
 client.tenants.update_user(
-    '<username>',
+    '<username_to_update>',
     '<tenant_name>',
     '<role_name>',
     _get_data=True,
@@ -710,7 +710,7 @@ auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
 headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
-    'username': '<username>',
+    'username': '<username_to_update>',
     'role': '<role_name>',
 }
 response = requests.patch(
@@ -746,7 +746,7 @@ Update a user in a tenant.
 
 Property | Type | Description
 --------- | ------- | -----------
-`username` | string | The user name to remove from the tenant.
+`username_to_update` | string | The user name to remove from the tenant.
 `tenant_name` | string | The tenant name to add the user into it.
 `role_name` | string | The name of the role assigned to the user in the tenant. If not passed the default tenant role will be used.
 
@@ -763,7 +763,7 @@ $ curl -X DELETE \
     -H "Content-Type: application/json"
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    -d '{"username": "<username>", "tenant_name": "<tenant_name>"}' \
+    -d '{"username": "<username_to_remove>", "tenant_name": "<tenant_name>"}' \
      "http://<manager_ip>/api/v3.1/tenants/users"
 ```
 
@@ -776,7 +776,7 @@ client = CloudifyClient(
     password='<manager_password>',
     tenant='<manager_tenant>',
 )
-client.tenants.remove_user('<username>', '<tenant_name>')
+client.tenants.remove_user('<username_to_remove>', '<tenant_name>')
 
 # Using requests
 import requests
@@ -787,7 +787,7 @@ auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
 headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
-    'username': '<username>',
+    'username': '<username_to_remove>',
 }
 response = requests.delete(
     url,
@@ -815,7 +815,7 @@ $ curl -X DELETE \
     -H "Content-Type: application/json"
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    -d '{"username": "<username>", "tenant_name": "<tenant_name>"}' \
+    -d '{"username": "<username_to_remove>", "tenant_name": "<tenant_name>"}' \
      "http://<manager_ip>/api/v3.1/tenants/users?_get_data=true"
 ```
 
@@ -829,7 +829,7 @@ client = CloudifyClient(
     tenant='<manager_tenant>',
 )
 client.tenants.remove_user(
-    '<username>',
+    '<username_to_remove>',
     '<tenant_name>',
     _get_data=True,
 )
@@ -843,7 +843,7 @@ auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
 headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'tenant_name': '<tenant_name>',
-    'username': '<username>',
+    'username': '<username_to_remove>',
 }
 response = requests.delete(
     url,
@@ -858,7 +858,7 @@ response.json()
 
 ```json
 {
-    "name": "tenant_name",
+    "name": "<tenant_name>",
     "groups": {},
     "users": {}
 }
@@ -871,7 +871,7 @@ Delete a user from a tenant.
 
 Property | Type | Description
 --------- | ------- | -----------
-`username` | string | The user name to remove from the tenant.
+`username_to_remove` | string | The user name to remove from the tenant.
 `tenant_name` | string | The tenant name to add the user into it.
 
 ### Response
@@ -1026,7 +1026,7 @@ $ curl -X PATCH \
     -H "Content-Type: application/json"
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    -d '{"username": "<username>", "group_name": "<group_name>", "role": "<role_name>"}' \
+    -d '{"tenant_name": "<tenant_name>", "group_name": "<group_name>", "role": "<role_name>"}' \
      "http://<manager_ip>/api/v3.1/tenants/user-groups"
 ```
 
@@ -1083,7 +1083,7 @@ $ curl -X PATCH \
     -H "Content-Type: application/json"
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    -d '{"username": "<username>", "group_name": "<group_name>", "role": "<role_name>"}' \
+    -d '{"tenant_name": "<tenant_name>", "group_name": "<group_name>", "role": "<role_name>"}' \
      "http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true"
 ```
 

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -81,7 +81,6 @@ response.json()
 > Request Example - Get user and user group details
 
 ```shell
-# Get user and user group details
 $ curl -X GET \
     -H "Tenant: default_tenant" \
     -u <user>:<password> \
@@ -468,7 +467,7 @@ A `Tenant` resource.
 ## Update User in Tenant
 
 
-> Request Example
+> Request Example - Get user and user group counts
 
 ```shell
 $ curl -X PATCH \
@@ -484,26 +483,17 @@ $ curl -X PATCH \
 client.tenants.update_user(<user-name>, <tenant-name>, <role_name>)
 
 # Using requests
-import requests
-from requests.auth import HTTPBasicAuth
-
 url = 'http://<manager-ip>/api/v3.1/tenants/users'
-headers = {'Tenant': '<tenant-name>'}
 payload = {
     'tenant_name': <tenant-name>,
     'username': <user>,
     'role': <role_name>,
 }
-response = requests.patch(
-    url,
-    auth=HTTPBasicAuth(<user>, <password>),
-    headers=headers,
-    json=payload,
-)
+response = requests.patch(url, auth=auth, headers=headers, json=payload)
 response.json()
 ```
 
-> Response Example
+> Response Example - Get user and user group counts
 
 ```json
 {
@@ -513,6 +503,48 @@ response.json()
 }
 ```
 
+> Request Example - Get user and user group details
+
+```shell
+$ curl -X PATCH \
+    -H "Content-Type: application/json"
+    -H "Tenant: <tenant-name>" \
+    -u <user>:<password> \
+    -d '{"username": <user-name>, "tenant_name": <tenant-name>, "role": <role_name>}' \
+     "http://<manager-ip>/api/v3.1/tenants/users?_get_data=true"
+```
+
+```python
+# Using Cloudify client
+client.tenants.update_user(<user-name>, <tenant-name>, <role_name>, _get_data=True)
+
+# Using requests
+url = 'http://<manager-ip>/api/v3.1/tenants/users?_get_data=true'
+payload = {
+    'tenant_name': <tenant-name>,
+    'username': <user>,
+    'role': <role_name>,
+}
+response = requests.patch(url, auth=auth, headers=headers, json=payload)
+response.json()
+```
+
+> Response Example - Get user and user group details
+
+```json
+{
+  "name": "<tenant-name>",
+  "groups": {},
+  "users": {
+    "my-user": {
+      "tenant-role": "<role>",
+      "roles": [
+        "<role>"
+      ]
+    }
+  }
+}
+```
 `PATCH "{manager-ip}/api/v3.1/tenants/users"`
 
 Update a user in a tenant.

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -23,8 +23,8 @@ Attribute | Type | Description
 
 ```shell
 $ curl -X GET \
-    -H "Tenant: default_tenant" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     "http://<manager_ip>/api/v3.1/tenants"
 ```
 
@@ -79,8 +79,8 @@ response.json()
 
 ```shell
 $ curl -X GET \
-    -H "Tenant: default_tenant" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     "http://<manager_ip>/api/v3.1/tenants?_get_data=true"
 ```
 
@@ -154,8 +154,8 @@ Field | Type | Description
 
 ```shell
 $ curl -X GET \
-    -H "Tenant: default_tenant" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     "http://<manager_ip>/api/v3.1/tenants/{tenant_name}"
 ```
 
@@ -199,8 +199,8 @@ response.json()
 
 ```shell
 $ curl -X GET \
-    -H "Tenant: default_tenant" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     "http://<manager_ip>/api/v3.1/tenants/{tenant_name}?_get_data=true"
 ```
 
@@ -266,8 +266,8 @@ A `Tenant` resource.
 
 ```shell
 $ curl -X POST \
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     "http://<manager_ip>/api/v3.1/tenants/<new_tenant_name>"
 ```
 
@@ -312,8 +312,8 @@ response.json()
 
 ```shell
 $ curl -X POST \
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     "http://<manager_ip>/api/v3.1/tenants/<new_tenant_name>?_get_data=true"
 ```
 
@@ -372,8 +372,8 @@ A `Tenant` resource.
 
 ```shell
 $ curl -X DELETE \
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     "http://<manager_ip>/api/v3.1/tenants/<tenant_name_to_delete>"
 ```
 
@@ -418,8 +418,8 @@ response.json()
 
 ```shell
 $ curl -X DELETE \
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     "http://<manager_ip>/api/v3.1/tenants/<tenant_name_to_delete>?_get_data=true"
 ```
 
@@ -480,8 +480,8 @@ A `Tenant` resource.
 ```shell
 $ curl -X PUT \
     -H "Content-Type: application/json" \
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     -d '{"username": "<username>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
     "http://<manager_ip>/api/v3.1/tenants/users"
 ```
@@ -537,8 +537,8 @@ response.json()
 ```shell
 $ curl -X PUT \
     -H "Content-Type: application/json" \
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     -d '{"username": <username>, "tenant_name": <tenant_name>, "role": <role_name>}' \
     "http://<manager_ip>/api/v3.1/tenants/users?_get_data=true"
 ```
@@ -622,8 +622,8 @@ A `Tenant` resource.
 ```shell
 $ curl -X PATCH \
     -H "Content-Type: application/json"
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     -d '{"username": "<username>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
      "http://<manager_ip>/api/v3.1/tenants/users"
 ```
@@ -679,8 +679,8 @@ response.json()
 ```shell
 $ curl -X PATCH \
     -H "Content-Type: application/json"
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     -d '{"username": <username>, "tenant_name": <tenant_name>, "role": <role_name>}' \
      "http://<manager_ip>/api/v3.1/tenants/users?_get_data=true"
 ```
@@ -761,8 +761,8 @@ A `Tenant` resource.
 ```shell
 $ curl -X DELETE \
     -H "Content-Type: application/json"
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     -d '{"username": "<username>", "tenant_name": "<tenant_name>"}' \
      "http://<manager_ip>/api/v3.1/tenants/users"
 ```
@@ -813,8 +813,8 @@ response.json()
 ```shell
 $ curl -X DELETE \
     -H "Content-Type: application/json"
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     -d '{"username": "<username>", "tenant_name": "<tenant_name>"}' \
      "http://<manager_ip>/api/v3.1/tenants/users?_get_data=true"
 ```
@@ -888,8 +888,8 @@ A `Tenant` resource.
 ```shell
 $ curl -X PUT \
     -H "Content-Type: application/json" \
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     -d '{"group_name": "<group_name>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
     "http://<manager_ip>/api/v3.1/tenants/user-groups"
 ```
@@ -945,8 +945,8 @@ response.json()
 ```shell
 $ curl -X PUT \
     -H "Content-Type: application/json" \
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     -d '{"group_name": "<group_name>", "tenant_name": "<tenant_name>", "role": "<role_name>"}' \
     "http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true"
 ```
@@ -1024,8 +1024,8 @@ A `Tenant` resource.
 ```shell
 $ curl -X PATCH \
     -H "Content-Type: application/json"
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     -d '{"username": "<username>", "group_name": "<group_name>", "role": "<role_name>"}' \
      "http://<manager_ip>/api/v3.1/tenants/user-groups"
 ```
@@ -1081,8 +1081,8 @@ response.json()
 ```shell
 $ curl -X PATCH \
     -H "Content-Type: application/json"
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     -d '{"username": "<username>", "group_name": "<group_name>", "role": "<role_name>"}' \
      "http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true"
 ```
@@ -1159,8 +1159,8 @@ A `Tenant` resource.
 ```shell
 $ curl -X DELETE \
     -H "Content-Type: application/json" \
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     -d '{"group_name": "<group_name>", "tenant_name": "<tenant_name>"}' \
     "http://<manager_ip>/api/v3.1/tenants/user-groups"
 ```
@@ -1211,8 +1211,8 @@ response.json()
 ```shell
 $ curl -X DELETE \
     -H "Content-Type: application/json" \
-    -H "Tenant: <tenant_name>" \
-    -u <username>:<password> \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
     -d '{"group_name": "<group_name>", "tenant_name": "<tenant_name>"}' \
     "http://<manager_ip>/api/v3.1/tenants/user-groups?_get_data=true"
 ```


### PR DESCRIPTION
In this PR, the tenants examples are updated to show how to use the `get_data` flag.

In following requests the `users` and `user-groups` sections will be updated as well.