### PR TITLE
CFY-7373. Fix request body parameter names

### DIFF
--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -615,6 +615,8 @@ Valid tenant roles are:
 
 * `manager` - User that can manage tenants
 
+* `operations` - User that can deploy and execute workflows, but cannot manage blueprints or plugins
+
 * `user` - Regular user, can perform actions on tenants resources
 
 * `viewer` - User that can only view tenant resources
@@ -764,6 +766,8 @@ Property | Type | Description
 Valid tenant roles are:
 
 * `manager` - User that can manage tenants
+
+* `operations` - User that can deploy and execute workflows, but cannot manage blueprints or plugins
 
 * `user` - Regular user, can perform actions on tenants resources
 
@@ -1036,6 +1040,8 @@ Valid tenant roles are:
 
 * `manager` - User that can manage tenants
 
+* `operations` - User that can deploy and execute workflows, but cannot manage blueprints or plugins
+
 * `user` - Regular user, can perform actions on tenants resources
 
 * `viewer` - User that can only view tenant resources
@@ -1179,6 +1185,8 @@ Property | Type | Description
 Valid tenant roles are:
 
 * `manager` - User that can manage tenants
+
+* `operations` - User that can deploy and execute workflows, but cannot manage blueprints or plugins
 
 * `user` - Regular user, can perform actions on tenants resources
 

--- a/source/includes/_tenants.md
+++ b/source/includes/_tenants.md
@@ -607,9 +607,9 @@ Add a user to a tenant.
 
 Property | Type | Description
 --------- | ------- | -----------
-`username_to_add` | string | The user name to add to the tenant.
+`username` | string | The user name to add to the tenant.
 `tenant_name` | string | The name of the tenant to which to add the user.
-`role_name` | string | The name of the role assigned to the user in the tenant. If not passed the default tenant role will be used.
+`role` | string | The name of the role assigned to the user in the tenant. If not passed the default tenant role will be used.
 
 Valid tenant roles are:
 
@@ -757,9 +757,9 @@ Update a user in a tenant.
 
 Property | Type | Description
 --------- | ------- | -----------
-`username_to_update` | string | The user name to remove from the tenant.
+`username` | string | The user name to remove from the tenant.
 `tenant_name` | string | The tenant name to add the user into it.
-`role_name` | string | The name of the role assigned to the user in the tenant. If not passed the default tenant role will be used.
+`role` | string | The name of the role assigned to the user in the tenant. If not passed the default tenant role will be used.
 
 Valid tenant roles are:
 
@@ -891,7 +891,7 @@ Delete a user from a tenant.
 
 Property | Type | Description
 --------- | ------- | -----------
-`username_to_remove` | string | The user name to remove from the tenant.
+`username` | string | The user name to remove from the tenant.
 `tenant_name` | string | The tenant name to add the user into it.
 
 ### Response
@@ -1030,7 +1030,7 @@ Property | Type | Description
 --------- | ------- | -----------
 `group_name` | string | The name of the user group to add to the tenant.
 `tenant_name` | string | The name of the tenant to which to add the user group.
-`role_name` | string | The name of the role assigned to the users members of the group. If not passed the default tenant role will be used.
+`role` | string | The name of the role assigned to the users members of the group. If not passed the default tenant role will be used.
 
 Valid tenant roles are:
 
@@ -1174,7 +1174,7 @@ Property | Type | Description
 --------- | ------- | -----------
 `group_name` | string | The group name to update in the tenant.
 `tenant_name` | string | The tenant name to which the user group is assigned.
-`role_name` | string | The name of the role assigned to the user in the tenant. If not passed the default tenant role will be used.
+`role` | string | The name of the role assigned to the user in the tenant. If not passed the default tenant role will be used.
 
 Valid tenant roles are:
 

--- a/source/includes/_user_group.md
+++ b/source/includes/_user_group.md
@@ -601,7 +601,7 @@ Add a user to user group.
 
 Property | Type | Description
 --------- | ------- | -----------
-`username_to_add` | string | The name of the user to add to the group.
+`username` | string | The name of the user to add to the group.
 `group_name` | string | The name of the group to which to add the user.
 
 ### Response
@@ -729,7 +729,7 @@ Delete a user from a user group.
 
 Property | Type | Description
 --------- | ------- | -----------
-`username_to_remove` | string | The name of the user to remove from the group.
+`username` | string | The name of the user to remove from the group.
 `group_name` | string | The name of the group from which to remove the user.
 
 ### Response

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -403,9 +403,9 @@ Creates a new user.
 
 Property | Type | Description
 --------- | ------- | -----------
-`new_username` | string | The username.
+`username` | string | The username.
 `password` | string | The user password.
-`role_name` | string | The user role. One of the following: `sys_admin`, `default`.
+`role` | string | The user role. One of the following: `sys_admin`, `default`.
 
 Valid system roles are:
 
@@ -649,7 +649,7 @@ Specify a password.
 
 Property | Type | Description
 --------- | ------- | -----------
-`new_password` | string | The new user password.
+`password` | string | The new user password.
 
 ### Response
 A `User` resource.
@@ -776,7 +776,7 @@ Set a new system role for the user.
 
 Property | Type | Description
 --------- | ------- | -----------
-`new_role_name` | string | The user role. One of the following: `sys_admin`, `default`.
+`role` | string | The user role. One of the following: `sys_admin`, `default`.
 
 Valid system roles are:
 


### PR DESCRIPTION
In this PR, the request body parameter names that were wrongly updated are fixed.

In addition to this, the new `operations` tenant role is added.