### PR TITLE
CFY-7562. Add secret update_if_exists flag

### DIFF
--- a/source/includes/_secrets.md
+++ b/source/includes/_secrets.md
@@ -62,7 +62,7 @@ client.secrets.list()
 }
 ```
 
-`GET "{manager-ip}/api/v3.1/secrets"`
+`GET "{manager_ip}/api/v3.1/secrets"`
 
 List all secrets.
 
@@ -81,7 +81,7 @@ Field | Type | Description
 $ curl -X GET \
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    "http://<manager_ip>/api/v3.1/secrets/<secret-key>"
+    "http://<manager_ip>/api/v3.1/secrets/<secret_key>"
 ```
 
 ```python
@@ -93,7 +93,7 @@ client = CloudifyClient(
         password='<manager_password>',
         tenant='<manager_tenant>',
 )
-client.secrets.get(<secret-key>)
+client.secrets.get(<secret_key>)
 ```
 
 > Response Example
@@ -111,12 +111,12 @@ client.secrets.get(<secret-key>)
 }
 ```
 
-`GET "{manager-ip}/api/v3.1/secrets/{secret-key}"`
+`GET "{manager_ip}/api/v3.1/secrets/{secret_key}"`
 
 Retrieves a specific secret.
 
 ### URI Parameters
-* `secret-key`: The key of the secret to retrieve.
+* `secret_key`: The key of the secret to retrieve.
 
 ### Response
 A `Secret` resource.
@@ -132,8 +132,8 @@ $ curl -X PUT \
     -H "Content-Type: application/json" \
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    -d '{"value": <new-secret-value>}' \
-    "http://<manager-ip>/api/v3.1/secrets/<new-secret-key>"
+    -d '{"value": <new_secret_value>}' \
+    "http://<manager_ip>/api/v3.1/secrets/<new_secret_key>"
 ```
 
 ```python
@@ -145,7 +145,7 @@ client = CloudifyClient(
         password='<manager_password>',
         tenant='<manager_tenant>',
 )
-client.secrets.create(<new-secret-key>, <new-secret-value>)
+client.secrets.create(<new_secret_key>, <new_secret_value>)
 ```
 
 > Response Example
@@ -163,12 +163,12 @@ client.secrets.create(<new-secret-key>, <new-secret-value>)
 }
 ```
 
-`PUT -d '{"value": <new-secret-value>}' "{manager-ip}/api/v3.1/secrets/{new-secret-key}"`
+`PUT -d '{"value": <new_secret_value>}' "{manager_ip}/api/v3.1/secrets/{new_secret_key}"`
 
 Creates a secret.
 
 ### URI Parameters
-* `new-secret-key`: The key of the secret to create.
+* `new_secret_key`: The key of the secret to create.
 
 ### Request Body
 Property | Type | Description
@@ -189,8 +189,8 @@ $ curl -X PATCH \
     -H "Content-Type: application/json" \
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    -d '{"value": <new-value>}' \
-    "http://<manager_ip>/api/v3.1/secrets/<secret-key>"
+    -d '{"value": <new_secret_value>}' \
+    "http://<manager_ip>/api/v3.1/secrets/<secret_key>"
 ```
 
 ```python
@@ -202,7 +202,7 @@ client = CloudifyClient(
         password='<manager_password>',
         tenant='<manager_tenant>',
 )
-client.secrets.update(<secret-key>, <new-value>)
+client.secrets.update(<secret_key>, <new_secret_value>)
 ```
 
 > Response Example
@@ -220,12 +220,12 @@ client.secrets.update(<secret-key>, <new-value>)
 }
 ```
 
-`PATCH -d '{"value": <new-value>}' "{manager-ip}/api/v3.1/secrets/{secret-key}"`
+`PATCH -d '{"value": <new_secret_value>}' "{manager_ip}/api/v3.1/secrets/{secret_key}"`
 
 Updates a secret.
 
 ### URI Parameters
-* `secret-key`: The key of the secret to update.
+* `secret_key`: The key of the secret to update.
 
 ### Request Body
 Property | Type | Description
@@ -245,7 +245,7 @@ A `Secret` resource.
 $ curl -X DELETE \
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    "http://<manager_ip>/api/v3.1/secrets/<secret-key>"
+    "http://<manager_ip>/api/v3.1/secrets/<secret_key>"
 ```
 
 ```python
@@ -257,7 +257,7 @@ client = CloudifyClient(
         password='<manager_password>',
         tenant='<manager_tenant>',
 )
-client.secrets.delete(<secret-key>)
+client.secrets.delete(<secret_key>)
 ```
 
 > Response Example
@@ -275,12 +275,12 @@ client.secrets.delete(<secret-key>)
 }
 ```
 
-`DELETE "{manager-ip}/api/v3.1/secrets/{secret-key}"`
+`DELETE "{manager_ip}/api/v3.1/secrets/{secret_key}"`
 
 Deletes a secret.
 
 ### URI Parameters
-* `secret-key`: The key of the secret to delete.
+* `secret_key`: The key of the secret to delete.
 
 ### Response
 A `Secret` resource.
@@ -296,7 +296,7 @@ $ curl -X PATCH \
     -H "Content-Type: application/json" \
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    "http://<manager-ip>/api/v3.1/secrets/<secret-key>/set-global"
+    "http://<manager_ip>/api/v3.1/secrets/<secret_key>/set-global"
 ```
 
 ```python
@@ -308,7 +308,7 @@ client = CloudifyClient(
         password='<manager_password>',
         tenant='<manager_tenant>',
 )
-client.secrets.set_global(<secret-key>)
+client.secrets.set_global(<secret_key>)
 ```
 
 > Response Example
@@ -326,12 +326,12 @@ client.secrets.set_global(<secret-key>)
 }
 ```
 
-`PATCH "{manager-ip}/api/v3.1/secrets/{secret-key}/set-global"`
+`PATCH "{manager_ip}/api/v3.1/secrets/{secret_key}/set-global"`
 
 Set the secret's availability to global.
 
 ### URI Parameters
-* `secret-key`: The key of the secret to update.
+* `secret_key`: The key of the secret to update.
 
 
 ### Response

--- a/source/includes/_secrets.md
+++ b/source/includes/_secrets.md
@@ -35,7 +35,10 @@ Attribute | Type | Description
 > Request Example
 
 ```shell
-$ curl -X GET --header "tenant: <tenant-name>" -u user:password "http://<manager-ip>/api/v3.1/secrets"
+$ curl -X GET \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
+    "http://<manager_ip>/api/v3.1/secrets"
 ```
 
 ```python
@@ -78,7 +81,10 @@ Field | Type | Description
 > Request Example
 
 ```shell
-$ curl -X GET --header "tenant: <tenant-name>" -u user:password "http://<manager-ip>/api/v3.1/secrets/<secret-key>"
+$ curl -X GET \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
+    "http://<manager_ip>/api/v3.1/secrets/<secret-key>"
 ```
 
 ```python
@@ -118,7 +124,12 @@ A `Secret` resource.
 > Request Example
 
 ```shell
-$ curl -X PUT -H "Content-Type: application/json" -H "tenant: <tenant-name>" -d '{"value": <new-secret-value>}' -u user:password "http://<manager-ip>/api/v3.1/secrets/<new-secret-key>"
+$ curl -X PUT \
+    -H "Content-Type: application/json" \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
+    -d '{"value": <new-secret-value>}' \
+    "http://<manager-ip>/api/v3.1/secrets/<new-secret-key>"
 ```
 
 ```python
@@ -163,7 +174,12 @@ A `Secret` resource.
 > Request Example
 
 ```shell
-$ curl -X PATCH -H "Content-Type: application/json" -H "tenant: <tenant-name>" -d '{"value": <new-value>}' -u user:password "http://<manager-ip>/api/v3.1/secrets/<secret-key>"
+$ curl -X PATCH \
+    -H "Content-Type: application/json" \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
+    -d '{"value": <new-value>}' \
+    "http://<manager_ip>/api/v3.1/secrets/<secret-key>"
 ```
 
 ```python
@@ -208,7 +224,10 @@ A `Secret` resource.
 > Request Example
 
 ```shell
-$ curl -X DELETE -H "Content-Type: application/json" -H "tenant: <tenant-name>" -u user:password "http://<manager-ip>/api/v3.1/secrets/<secret-key>"
+$ curl -X DELETE \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
+    "http://<manager_ip>/api/v3.1/secrets/<secret-key>"
 ```
 
 ```python
@@ -248,8 +267,11 @@ A `Secret` resource.
 > Request Example
 
 ```shell
-$ curl -X PATCH -H "Content-Type: application/json" -H "tenant: <tenant-name>"
-    -u user:password "http://<manager-ip>/api/v3.1/secrets/<secret-key>/set-global"
+$ curl -X PATCH \
+    -H "Content-Type: application/json" \
+    -H "Tenant: <manager_tenant>" \
+    -u <manager_username>:<manager_password> \
+    "http://<manager-ip>/api/v3.1/secrets/<secret-key>/set-global"
 ```
 
 ```python

--- a/source/includes/_secrets.md
+++ b/source/includes/_secrets.md
@@ -3,16 +3,6 @@
 ## The Secret Resource
 
 
-```python
-# include this code when using cloudify python client
-from cloudify_rest_client import CloudifyClient
-client = CloudifyClient(
-        host='<manager-ip>',
-        username='<manager-username>',
-        password='<manager-password>',
-        tenant='<manager-tenant>')
-```
-
 A Secret resource is a key-value pair saved per tenant.
 A user can ensure all secrets (such as credentials to IaaS environments, passwords, etc) are kept in a secured manner,
 and adhere to isolation requirements between different tenants.
@@ -42,7 +32,14 @@ $ curl -X GET \
 ```
 
 ```python
-# Python Client-
+# Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+        host='<manager_ip>',
+        username='<manager_username>',
+        password='<manager_password>',
+        tenant='<manager_tenant>',
+)
 client.secrets.list()
 ```
 
@@ -88,7 +85,14 @@ $ curl -X GET \
 ```
 
 ```python
-# Python Client-
+# Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+        host='<manager_ip>',
+        username='<manager_username>',
+        password='<manager_password>',
+        tenant='<manager_tenant>',
+)
 client.secrets.get(<secret-key>)
 ```
 
@@ -133,7 +137,14 @@ $ curl -X PUT \
 ```
 
 ```python
-# Python Client-
+# Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+        host='<manager_ip>',
+        username='<manager_username>',
+        password='<manager_password>',
+        tenant='<manager_tenant>',
+)
 client.secrets.create(<new-secret-key>, <new-secret-value>)
 ```
 
@@ -183,7 +194,14 @@ $ curl -X PATCH \
 ```
 
 ```python
-# Python Client-
+# Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+        host='<manager_ip>',
+        username='<manager_username>',
+        password='<manager_password>',
+        tenant='<manager_tenant>',
+)
 client.secrets.update(<secret-key>, <new-value>)
 ```
 
@@ -231,7 +249,14 @@ $ curl -X DELETE \
 ```
 
 ```python
-# Python Client-
+# Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+        host='<manager_ip>',
+        username='<manager_username>',
+        password='<manager_password>',
+        tenant='<manager_tenant>',
+)
 client.secrets.delete(<secret-key>)
 ```
 
@@ -275,7 +300,14 @@ $ curl -X PATCH \
 ```
 
 ```python
-# Python Client
+# Using Cloudify client
+from cloudify_rest_client import CloudifyClient
+client = CloudifyClient(
+        host='<manager_ip>',
+        username='<manager_username>',
+        password='<manager_password>',
+        tenant='<manager_tenant>',
+)
 client.secrets.set_global(<secret-key>)
 ```
 

--- a/source/includes/_secrets.md
+++ b/source/includes/_secrets.md
@@ -165,7 +165,7 @@ $ curl -X PUT \
     -H "Content-Type: application/json" \
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    -d '{"value": <new_secret_value>, "upsert": false}' \
+    -d '{"value": <new_secret_value>, "update_if_exists": false}' \
     "http://<manager_ip>/api/v3.1/secrets/<new_secret_key>"
 ```
 
@@ -181,7 +181,7 @@ client = CloudifyClient(
 client.secrets.create(
     <new_secret_key>,
     <new_secret_value>,
-    upsert=False,
+    update_if_exists=False,
 )
 
 # Using requests
@@ -193,7 +193,7 @@ auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
 headers = {'Tenant': '<manager_tenant>'}
 payload = {
     'value': '<new_secret_value>',
-    'upsert': False,
+    'update_if_exists': False,
 }
 response = requests.get(
     url,
@@ -230,7 +230,7 @@ Creates a secret.
 Property | Type | Description
 --------- | ------- | -----------
 `value` | string | The secret's value.
-`upsert` | boolean | Update value if secret already exists (optional, defaults to false).
+`update_if_exists` | boolean | Update value if secret already exists (optional, defaults to false).
 
 ### Response
 A `Secret` resource.

--- a/source/includes/_secrets.md
+++ b/source/includes/_secrets.md
@@ -41,24 +41,43 @@ client = CloudifyClient(
         tenant='<manager_tenant>',
 )
 client.secrets.list()
+
+# Using request
+import requests
+from requests.auth import HTTPBasicAuth
+
+url = 'http://<manager_ip>/api/v3.1/secrets'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+response = requests.get(
+    url,
+    auth=auth,
+    headers=headers,
+)
+response.json()
 ```
 
 > Response Example
 
 ```json
 {
- "items":
-    [
+    "items": [
         {
-            "key": "key1",
-            "created_at": "2017-03-20T08:23:31.276Z",
-            "updated_at": "2017-03-20T08:43:19.468Z",
-            "permission": "creator",
-            "tenant_name": "default_tenant",
+            "created_at": "2017-11-24T10:42:29.756Z",
             "created_by": "admin",
-            "resource_availability": "tenant"
+            "key": "<secret_key>",
+            "resource_availability": "tenant",
+            "tenant_name": "default_tenant",
+            "updated_at": "2017-11-24T10:42:29.756Z"
         }
-    ]
+    ],
+    "metadata": {
+        "pagination": {
+            "offset": 0,
+            "size": 0,
+            "total": 1
+        }
+    }
 }
 ```
 

--- a/source/includes/_secrets.md
+++ b/source/includes/_secrets.md
@@ -396,20 +396,34 @@ client = CloudifyClient(
         tenant='<manager_tenant>',
 )
 client.secrets.set_global(<secret_key>)
+
+# Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
+url = 'http://<manager_ip>/api/v3.1/secrets/<secret_key>/set-global'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+response = requests.patch(
+    url,
+    auth=auth,
+    headers=headers,
+)
+response.json()
 ```
 
 > Response Example
 
 ```json
 {
-    "key": "key1",
-    "value": "value1",
-    "created_at": "2017-03-20T08:23:31.276Z",
-    "updated_at": "2017-03-20T08:43:19.468Z",
-    "permission": "creator",
-    "tenant_name": "default_tenant",
+    "created_at": "2017-11-24T12:10:49.789Z",
     "created_by": "admin",
-    "resource_availability": "global"
+    "key": "<secret_key>",
+    "private_resource": false,
+    "resource_availability": "global",
+    "tenant_name": "default_tenant",
+    "updated_at": "2017-11-24T12:11:16.495Z",
+    "value": "<secret_value>"
 }
 ```
 

--- a/source/includes/_secrets.md
+++ b/source/includes/_secrets.md
@@ -42,7 +42,7 @@ client = CloudifyClient(
 )
 client.secrets.list()
 
-# Using request
+# Using requests
 import requests
 from requests.auth import HTTPBasicAuth
 
@@ -165,7 +165,7 @@ $ curl -X PUT \
     -H "Content-Type: application/json" \
     -H "Tenant: <manager_tenant>" \
     -u <manager_username>:<manager_password> \
-    -d '{"value": <new_secret_value>}' \
+    -d '{"value": <new_secret_value>, "upsert": false}' \
     "http://<manager_ip>/api/v3.1/secrets/<new_secret_key>"
 ```
 
@@ -178,21 +178,44 @@ client = CloudifyClient(
         password='<manager_password>',
         tenant='<manager_tenant>',
 )
-client.secrets.create(<new_secret_key>, <new_secret_value>)
+client.secrets.create(
+    <new_secret_key>,
+    <new_secret_value>,
+    upsert=False,
+)
+
+# Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
+url = 'http://<manager_ip>/api/v3.1/secrets/<new_secret_key>'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+payload = {
+    'value': '<new_secret_value>',
+    'upsert': False,
+}
+response = requests.get(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
+response.json()
 ```
 
 > Response Example
 
 ```json
 {
-    "key": "key1",
-    "value": "value1",
-    "created_at": "2017-03-20T08:23:31.276Z",
-    "updated_at": "2017-03-20T08:23:31.276Z",
-    "permission": "creator",
-    "tenant_name": "default_tenant",
+    "created_at": "2017-11-24T10:42:29.756Z",
     "created_by": "admin",
-    "resource_availability": "tenant"
+    "key": "<new_secret_key>",
+    "private_resource": false,
+    "resource_availability": "tenant",
+    "tenant_name": "default_tenant",
+    "updated_at": "2017-11-24T10:42:29.756Z",
+    "value": "<new_secret_value>"
 }
 ```
 
@@ -207,6 +230,7 @@ Creates a secret.
 Property | Type | Description
 --------- | ------- | -----------
 `value` | string | The secret's value.
+`upsert` | boolean | Update value if secret already exists (optional, defaults to false).
 
 ### Response
 A `Secret` resource.

--- a/source/includes/_secrets.md
+++ b/source/includes/_secrets.md
@@ -113,20 +113,34 @@ client = CloudifyClient(
         tenant='<manager_tenant>',
 )
 client.secrets.get(<secret_key>)
+
+# Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
+url = 'http://<manager_ip>/api/v3.1/secrets/<secret_key>'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+response = requests.get(
+    url,
+    auth=auth,
+    headers=headers,
+)
+response.json()
 ```
 
 > Response Example
 
 ```json
 {
-    "key": "key1",
-    "value": "value1",
-    "created_at": "2017-03-20T08:23:31.276Z",
-    "updated_at": "2017-03-20T08:43:19.468Z",
-    "permission": "creator",
-    "tenant_name": "default_tenant",
+    "created_at": "2017-11-24T10:42:29.756Z",
     "created_by": "admin",
-    "resource_availability": "tenant"
+    "key": "<secret_key>",
+    "private_resource": false,
+    "resource_availability": "tenant",
+    "tenant_name": "default_tenant",
+    "updated_at": "2017-11-24T10:42:29.756Z",
+    "value": "<secret_value>"
 }
 ```
 

--- a/source/includes/_secrets.md
+++ b/source/includes/_secrets.md
@@ -260,20 +260,36 @@ client = CloudifyClient(
         tenant='<manager_tenant>',
 )
 client.secrets.update(<secret_key>, <new_secret_value>)
+
+# Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
+url = 'http://<manager_ip>/api/v3.1/secrets/<secret_key>'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+payload = {'value': '<new_secret_value>'}
+response = requests.patch(
+    url,
+    auth=auth,
+    headers=headers,
+    json=payload,
+)
+response.json()
 ```
 
 > Response Example
 
 ```json
 {
-    "key": "key1",
-    "value": "value1",
-    "created_at": "2017-03-20T08:23:31.276Z",
-    "updated_at": "2017-03-20T08:43:19.468Z",
-    "permission": "creator",
-    "tenant_name": "default_tenant",
+    "created_at": "2017-11-24T11:01:05.357Z",
     "created_by": "admin",
-    "resource_availability": "tenant"
+    "key": "<secret_key>",
+    "private_resource": false,
+    "resource_availability": "tenant",
+    "tenant_name": "default_tenant",
+    "updated_at": "2017-11-24T12:02:38.296Z",
+    "value": "<new_secret_value>"
 }
 ```
 

--- a/source/includes/_secrets.md
+++ b/source/includes/_secrets.md
@@ -331,20 +331,34 @@ client = CloudifyClient(
         tenant='<manager_tenant>',
 )
 client.secrets.delete(<secret_key>)
+
+# Using requests
+import requests
+from requests.auth import HTTPBasicAuth
+
+url = 'http://<manager_ip>/api/v3.1/secrets/<secret_key>'
+auth = HTTPBasicAuth('<manager_username>', '<manager_password>')
+headers = {'Tenant': '<manager_tenant>'}
+response = requests.delete(
+    url,
+    auth=auth,
+    headers=headers,
+)
+response.json()
 ```
 
 > Response Example
 
 ```json
 {
-    "key": "key1",
-    "value": "value1",
-    "created_at": "2017-03-20T08:23:31.276Z",
-    "updated_at": "2017-03-20T08:43:19.468Z",
-    "permission": "creator",
-    "tenant_name": "default_tenant",
+    "created_at": "2017-11-24T11:01:05.357Z",
     "created_by": "admin",
-    "resource_availability": "tenant"
+    "key": "<secret_key>",
+    "private_resource": false,
+    "resource_availability": "tenant",
+    "tenant_name": "default_tenant",
+    "updated_at": "2017-11-24T12:05:30.190Z",
+    "value": "<secret_value>"
 }
 ```
 


### PR DESCRIPTION
In this PR, the documentation of the add secret command is updated to include the new `upsert` flag.

In addition to this, the documentation of the whole secrets section is updated to be more consistent with the rest of the documentation and also to include examples using the python requests library.

Related:
cloudify-cosmo/cloudify-rest-client#206
cloudify-cosmo/cloudify-cli#710