### PR TITLE
Move publishing to docs.cloudify.co

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   hosts:
-    docs.getcloudify.org: 127.0.0.1
+    docs.cloudify.co: 127.0.0.1
   ruby:
     version:
       2.2.1

--- a/s3_website.yml
+++ b/s3_website.yml
@@ -1,6 +1,6 @@
 s3_id: <%= ENV['S3_ACCESS_KEY_ID'] %>
 s3_secret: <%= ENV['S3_SECRET_KEY'] %>
-s3_bucket: docs.getcloudify.org
+s3_bucket: docs.cloudify.co
 s3_key_prefix: api/v3.1
 
 # Below are examples of all the available configurations.


### PR DESCRIPTION
Make sure the S3 access key belongs to a user with access to docs.cloudify.co