### PR TITLE
circleci build - adding patch due to circleci bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,10 @@ jobs:
                     echo ${LOCATION}
                     hugo -v --baseURL //docs.cloudify.co/api/$LOCATION
             - run:
-                name: Show directory contents
-                command: echo ls
+                name: Patch - forcefully add tar
+                command: |
+                    apk update
+                    apk add tar
             - persist_to_workspace:
                 root: .
                 paths:


### PR DESCRIPTION
The tar tool can not be found, which fails the step of persist_to_workspace so we forcefully add tar to the running docker.
This should be removed once the circleci issue will be resolved