### PR TITLE
Simplify the visibility note for dep-groups

### DIFF
--- a/content/_deployment_groups.md
+++ b/content/_deployment_groups.md
@@ -169,8 +169,7 @@ Note that this means that `new_deployments` can also be a list of empty objects.
  * `runtime_only_evaluation` - sets the `runtime_only_evaluation` flag for the deployment
  * `skip_plugins_validation` - sets the `skip_plugins_validation` flag for the deployment
 
-Visibility and private_resource are not parameters that can be passed in: instead, newly-created deployments
-inherit their visibility from the group.
+Visibility and private_resource for the newly-created deployment are inherited from the group.
 
 ### Deployment ID template
 

--- a/content/_deployment_groups.md
+++ b/content/_deployment_groups.md
@@ -278,7 +278,7 @@ Property | Type | Description
 `default_inputs` | object | Default inputs for creating new deployments in this group.
 `description` | string | A freeform description.
 `labels` | list | A list of labels to assign to the group.
-`visibility` | string | Optional parameter, defines who can see the deployment (default: tenant). **Supported for Cloudify Manager 4.3 and above.**
+`visibility` | string | Optional parameter, defines who can see the deployment (default: tenant).
 `deployment_ids` | list | A list of deployments this group should contain.
 `filter_id` | string | The group will contain deployments returned by this filter.
 `filter_rules` | list | The group will contain deployments returned by these filter rules.


### PR DESCRIPTION
Those parameters can be passed in for the group, they can't be passed in
inside `new_deployments`. Anyway, this wording is shorter and more
understandable.