### PR TITLE
RD-6639 Remove old set-global endpoints

### DIFF
--- a/content/_blueprints.md
+++ b/content/_blueprints.md
@@ -392,54 +392,6 @@ with open('<blueprint-archive-filename>.tar.gz', 'wb') as blueprint_archive:
 The blueprint as an archive using an `application/octet-stream` content type.
 
 
-## Set Global Blueprint
-
-> Request Example
-
-```shell
-$ curl -X PATCH -H "Content-Type: application/json" -H "tenant: <tenant-name>"
-    -u user:password "http://<manager-ip>/api/v3.1/blueprints/<blueprint-id>/set-global"
-```
-
-```python
-# Python Client
-client.blueprints.set_global('<blueprint-id>')
-```
-
-> Response Example
-
-```json
-{
-  "main_file_name": "singlehost-blueprint.yaml",
-  "description": "This blueprint installs a simple web server on the manager VM using Cloudify's script plugin.\n",
-  "tenant_name": "default_tenant",
-  "created_at": "2021-03-25T15:51:30.526Z",
-  "updated_at": "2021-03-25T15:51:30.526Z",
-  "created_by": "admin",
-  "private_resource": false,
-  "visibility": "global",
-  "plan": {
-    ...
-  },
-  "labels": [
-    ...
-  ],
-  "id": "hello-world"
-}
-```
-
-`PATCH "{manager-ip}/api/v3.1/blueprints/{blueprint-id}/set-global"`
-
-Set the blueprint's visibility to global.
-Will be deprecated soon. For Cloudify Manager 4.3 and above, use 'set-visibility'.
-
-### URI Parameters
-* `blueprint-id`: The id of the blueprint to update.
-
-### Response
-A `Blueprint` resource.
-
-
 ## Set Blueprint Visibility
 
 > Request Example

--- a/content/_plugins.md
+++ b/content/_plugins.md
@@ -354,57 +354,6 @@ Downloads a plugin.
 The requested plugin archive.
 
 
-## Set Global Plugin
-
-> Request Example
-
-```shell
-$ curl -X PATCH -H "Content-Type: application/json" -H "tenant: <tenant-name>"
-    -u user:password "http://<manager-ip>/api/v3.1/plugins/<plugin-id>/set-global"
-```
-
-```python
-# Python Client
-client.plugins.set_global(<plugin-id>)
-```
-
-> Response Example
-
-```json
-{
-  "distribution_release": "core",
-  "supported_py_versions": [
-    "py27"
-  ],
-  "uploaded_at": "2017-10-19T14:19:39.727Z",
-  "archive_name": "cloudify_openstack_plugin-2.0.1-py27-none-linux_x86_64-centos-Core.wgn",
-  "package_name": "cloudify-openstack-plugin",
-  "distribution_version": "7.0.1406",
-  "tenant_name": "default_tenant",
-  "excluded_wheels": [
-
-  ],
-  "created_by": "admin",
-  "distribution": "centos",
-  "package_source": "https://github.com/cloudify-cosmo/cloudify-openstack-plugin/archive/master.tar.gz",
-  "private_resource": false,
-  "visibility": "global",
-  "supported_platform": "linux_x86_64",
-  "package_version": "2.0.1",
-  "wheels": [
-    "keystoneauth1-2.19.0-py2.py3-none-any.whl",
-    "python_novaclient-7.0.0-py2.py3-none-any.whl",
-     ...
-  ],
-  "id": "c7f6757e-b48d-4c26-ab91-cfc8c1e4851c"
-}
-```
-
-`PATCH "{manager-ip}/api/v3.1/plugins/{plugin-id}/set-global"`
-
-Set the plugin's visibility to global.
-Will be deprecated soon. For Cloudify Manager 4.3 and above, use 'set-visibility'.
-
 ### URI Parameters
 * `plugin-id`: The id of the plugin to update.
 


### PR DESCRIPTION
The restclient already uses set-visibility for those. And we're way above 4.3 now :)

This is the other part of cloudify-cosmo/cloudify-manager#3989